### PR TITLE
Hotfix: conditionally include django_browser_reload setup

### DIFF
--- a/apps/config/settings.py
+++ b/apps/config/settings.py
@@ -170,7 +170,6 @@ MIDDLEWARE = (
     "ambient_toolbox.middleware.current_user.CurrentUserMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django_browser_reload.middleware.BrowserReloadMiddleware",
     "apps.room.middleware.RoomToRequestMiddleware",
     "apps.core.middleware.maintenance_middleware.MaintenanceMiddleware",
     # AxesMiddleware should be the last middleware in the MIDDLEWARE list.

--- a/apps/config/urls.py
+++ b/apps/config/urls.py
@@ -34,8 +34,10 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns.append(
-        path("__reload__/", include("django_browser_reload.urls")),
-    )
-    urlpatterns.append(
         *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
+    )
+
+if "django_browser_reload" in settings.INSTALLED_APPS:
+    urlpatterns.append(
+        path("__reload__/", include("django_browser_reload.urls")),
     )


### PR DESCRIPTION
Moved django_browser_reload setup to be conditionally added only if it's present in INSTALLED_APPS. Removed its middleware to ensure cleaner configuration and avoid potential errors when the package is unavailable.