### PR TITLE
Hotfix: Remove redundant Sentry test route

### DIFF
--- a/apps/config/urls.py
+++ b/apps/config/urls.py
@@ -3,21 +3,6 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
-
-def trigger_error(_):
-    """
-    View that intentionally raises a ZeroDivisionError to test error monitoring.
-    This is used for testing Sentry or other error tracking systems.
-    """
-    # This will cause a division by zero error
-    _ = 1 / 0
-
-    from django.http import HttpResponse
-
-    # This code will never be reached due to the error above
-    return HttpResponse("This page should never load properly")
-
-
 urlpatterns = [
     path("", include("apps.core.urls")),
     # Django Admin, use {% url 'admin:index' %}
@@ -28,7 +13,6 @@ urlpatterns = [
     path("room/", include("apps.room.urls")),
     path("transaction/", include("apps.transaction.urls")),
     path("webpush/", include("apps.webpush.urls")),
-    path("sentry/check/", trigger_error, name="sentry-test"),
     *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
 ]
 


### PR DESCRIPTION
Eliminates the `/sentry/check/` test route and `trigger_error` view, as they are no longer required for error monitoring purposes.

- Deleted the `trigger_error` view function designed for Sentry testing.
- Removed the route registration in `urls.py` for `/sentry/check/`.