### PR TITLE
Optimise "Create Room"

### DIFF
--- a/apps/room/templates/room/create.html
+++ b/apps/room/templates/room/create.html
@@ -7,7 +7,21 @@
             <div class="col-12 col-lg-7">
                 <div class="card border-0 shadow-sm">
                     <div class="card-body">
-                        <h1 class="h3 fw-semibold mb-4">{% trans "Create Room" %}</h1>
+                        <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-3 mb-4">
+                            <a class="btn btn-outline-secondary gap-2 d-flex align-items-center justify-content-center px-3 py-2 shadow-sm w-100 w-md-auto text-decoration-none"
+                               href="{{ room_list_url }}"
+                               role="button"
+                               aria-label="{% trans 'Back to rooms' %}"
+                               hx-get="{{ room_list_url }}"
+                               hx-target="#body"
+                               hx-indicator="#body-loading-spinner"
+                               hx-swap="innerHTML"
+                               hx-push-url="true">
+                                <i class="bi bi-arrow-left fs-5" aria-hidden="true"></i>
+                                {% trans "Back to rooms" %}
+                            </a>
+                            <h1 class="h3 fw-semibold mb-0">{% trans "Create Room" %}</h1>
+                        </div>
                         <form action="{% url 'room:create' %}" method="post">
                             {% csrf_token %}
                             <div class="mb-3">

--- a/apps/room/tests/test_views/test_room_create_view.py
+++ b/apps/room/tests/test_views/test_room_create_view.py
@@ -1,0 +1,30 @@
+import pytest
+from django.urls import reverse
+
+from apps.account.tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+class TestRoomCreateView:
+    @pytest.fixture
+    def owner(self):
+        return UserFactory(is_guest=False)
+
+    @pytest.fixture
+    def owner_client(self, client, owner):
+        client.force_login(owner)
+        return client
+
+    def test_back_button_targets_room_list(self, owner_client):
+        response = owner_client.get(reverse("room:create"))
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        room_list_url = reverse("room:list")
+        href_fragment = f"href={room_list_url}"
+        hx_get_fragment = f"hx-get={room_list_url}"
+
+        assert href_fragment in content
+        assert hx_get_fragment in content
+        assert 'bi-arrow-left' in content
+        assert 'Back to rooms' in content

--- a/apps/room/views/room_create_view.py
+++ b/apps/room/views/room_create_view.py
@@ -20,6 +20,7 @@ class RoomCreateView(mixins.LoginRequiredMixin, generic.CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["suggested_guests"] = SuggestedGuestService(user=self.request.user).get_suggested_guests()
+        context["room_list_url"] = self._build_room_list_url()
         return context
 
     def form_valid(self, form):
@@ -46,3 +47,10 @@ class RoomCreateView(mixins.LoginRequiredMixin, generic.CreateView):
 
             if form.is_valid():
                 form.save()
+
+    def _build_room_list_url(self) -> str:
+        base_url = reverse(viewname="room:list")
+        query_string = self.request.GET.urlencode()
+        if query_string:
+            return f"{base_url}?{query_string}"
+        return base_url


### PR DESCRIPTION
## Summary
- add a responsive, Bootstrap-styled back control on the room creation card that targets the room list via HTMX
- keep the `RoomCreateView` supplying a `room_list_url` (including any query params) so navigation links stay resilient
- add a regression test covering the new button markup and link

## Testing
- `uv run pytest`
- `uv run coverage run -m pytest`
- `uv run coverage report`
- `uv run ruff check --fix .`
- `./.venv/bin/djlint apps --reformat` *(fails: Python `multiprocessing` raises `PermissionError` when creating a semaphore)*

## Notes
- The `djlint` command crashes locally because the environment denies semaphore creation (see stderr for the `PermissionError`).
- Please re-run the pre-commit hooks once network access is stable so the `ruff`/`djlint` hooks can install properly.
- Adds context file under `.github-issues/issue-50.md` for the issue summary (directory is ignored by git).