### PR TITLE
fix: show real open debts and gross coverage on Money Overview

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # https://github.com/astral-sh/ruff-pre-commit/releases
-    rev: v0.15.10
+    rev: v0.15.11
     hooks:
       # Run the formatter.
       - id: ruff-format

--- a/apps/core/templatetags/core_tags.py
+++ b/apps/core/templatetags/core_tags.py
@@ -25,3 +25,11 @@ def json_script_nonce(context, value, element_id):
         nonce,
         mark_safe(json_str),
     )
+
+
+@register.filter
+def get_item(dictionary, key):
+    """Look up a dict value by key in templates: {{ my_dict|get_item:some_var }}"""
+    if isinstance(dictionary, dict):
+        return dictionary.get(key)
+    return None

--- a/apps/debt/tests/test_views/test_money_spent_on_room_view.py
+++ b/apps/debt/tests/test_views/test_money_spent_on_room_view.py
@@ -102,14 +102,38 @@ class TestMoneySpentOnRoomViewContext:
         assert open_debts[0]["total_open_debt"] == open_debt.value
 
     def test_max_open_debt_per_currency_reflects_max_unsettled(self, room, user, guest_user):
-        currency = room.preferred_currency
+        currency_a = room.preferred_currency
+        currency_b = CurrencyFactory(sign="¤")
         extra_user = UserFactory(name="Extra")
         room.users.add(extra_user)
 
-        Debt.objects.create(debitor=guest_user, creditor=user, room=room, currency=currency, value=Decimal("30"), settled=False)
-        Debt.objects.create(debitor=extra_user, creditor=user, room=room, currency=currency, value=Decimal("10"), settled=False)
+        Debt.objects.create(
+            debitor=guest_user,
+            creditor=user,
+            room=room,
+            currency=currency_a,
+            value=Decimal("30"),
+            settled=False,
+        )
+        Debt.objects.create(
+            debitor=extra_user,
+            creditor=user,
+            room=room,
+            currency=currency_a,
+            value=Decimal("10"),
+            settled=False,
+        )
+        Debt.objects.create(
+            debitor=guest_user,
+            creditor=user,
+            room=room,
+            currency=currency_b,
+            value=Decimal("55"),
+            settled=False,
+        )
 
         view = self._view_for_room(room)
         max_map = view.max_open_debt_per_currency
 
-        assert max_map[currency.sign] == Decimal("30")
+        assert max_map[currency_a.sign] == Decimal("30")
+        assert max_map[currency_b.sign] == Decimal("55")

--- a/apps/debt/tests/test_views/test_money_spent_on_room_view.py
+++ b/apps/debt/tests/test_views/test_money_spent_on_room_view.py
@@ -5,6 +5,7 @@ import pytest
 
 from apps.account.tests.factories import UserFactory
 from apps.currency.tests.factories import CurrencyFactory
+from apps.debt.models import Debt
 from apps.debt.views.money_spent_on_room_view.money_spent_on_room_view import MoneySpentOnRoomView
 from apps.room.tests.factories import RoomFactory
 from apps.transaction.tests.factories import ChildTransactionFactory, ParentTransactionFactory
@@ -64,10 +65,51 @@ class TestMoneySpentOnRoomViewContext:
         assert total_spent[currency_a.sign] == Decimal("35")
         assert total_spent[currency_b.sign] == Decimal("10")
 
-        owed = list(view.money_owed_per_person_qs)
-        owed_map = {(entry["paid_for__name"], entry["currency_sign"]): entry["total_owed_per_person"] for entry in owed}
-        assert owed_map[(guest_user.name, currency_a.sign)] == Decimal("10")
-        assert owed_map[(guest_user.name, currency_b.sign)] == Decimal("7")
-        assert owed_map[(payee_third.name, currency_a.sign)] == Decimal("5")
-        assert owed_map[(payer_primary.name, currency_b.sign)] == Decimal("3")
-        assert (payer_primary.name, currency_a.sign) not in owed_map
+        covered = list(view.money_covered_for_person_qs)
+        covered_map = {
+            (entry["paid_for__name"], entry["currency_sign"]): entry["total_covered_for_person"] for entry in covered
+        }
+        assert covered_map[(guest_user.name, currency_a.sign)] == Decimal("10")
+        assert covered_map[(guest_user.name, currency_b.sign)] == Decimal("7")
+        assert covered_map[(payee_third.name, currency_a.sign)] == Decimal("5")
+        assert covered_map[(payer_primary.name, currency_b.sign)] == Decimal("3")
+        assert (payer_primary.name, currency_a.sign) not in covered_map
+
+    def test_open_debts_per_person_qs_only_returns_unsettled(self, room, user, guest_user):
+        currency = room.preferred_currency
+        open_debt = Debt.objects.create(
+            debitor=guest_user,
+            creditor=user,
+            room=room,
+            currency=currency,
+            value=Decimal("12.50"),
+            settled=False,
+        )
+        Debt.objects.create(
+            debitor=guest_user,
+            creditor=user,
+            room=room,
+            currency=currency,
+            value=Decimal("5.00"),
+            settled=True,
+        )
+
+        view = self._view_for_room(room)
+        open_debts = list(view.open_debts_per_person_qs)
+
+        assert len(open_debts) == 1
+        assert open_debts[0]["debitor_name"] == guest_user.name
+        assert open_debts[0]["total_open_debt"] == open_debt.value
+
+    def test_max_open_debt_per_currency_reflects_max_unsettled(self, room, user, guest_user):
+        currency = room.preferred_currency
+        extra_user = UserFactory(name="Extra")
+        room.users.add(extra_user)
+
+        Debt.objects.create(debitor=guest_user, creditor=user, room=room, currency=currency, value=Decimal("30"), settled=False)
+        Debt.objects.create(debitor=extra_user, creditor=user, room=room, currency=currency, value=Decimal("10"), settled=False)
+
+        view = self._view_for_room(room)
+        max_map = view.max_open_debt_per_currency
+
+        assert max_map[currency.sign] == Decimal("30")

--- a/apps/debt/views/money_spent_on_room_view/money_spent_on_room_view.py
+++ b/apps/debt/views/money_spent_on_room_view/money_spent_on_room_view.py
@@ -1,7 +1,8 @@
-from django.db.models import F, QuerySet, Sum
+from django.db.models import F, Max, QuerySet, Sum
 from django.views import generic
 from django_context_decorator import context
 
+from apps.debt.models import Debt
 from apps.debt.views.mixins.debt_base_context import DebtBaseContext
 from apps.debt.views.money_spent_on_room_view.room_child_transaction_queryset_mixin import (
     RoomChildTransactionQuerysetMixin,
@@ -36,11 +37,41 @@ class MoneySpentOnRoomView(RoomChildTransactionQuerysetMixin, DebtBaseContext, g
 
     @context
     @property
-    def money_owed_per_person_qs(self) -> QuerySet[dict[str, object]]:
+    def money_covered_for_person_qs(self) -> QuerySet[dict[str, object]]:
+        """Gross amount paid by others for each person (excluding self-paid shares)."""
         return (
             self.get_base_queryset()
             .exclude(paid_for=F("parent_transaction__paid_by"))
             .values("paid_for__name", "parent_transaction__currency__sign")
-            .annotate(currency_sign=F("parent_transaction__currency__sign"), total_owed_per_person=Sum("value"))
+            .annotate(
+                currency_sign=F("parent_transaction__currency__sign"),
+                total_covered_for_person=Sum("value"),
+            )
             .order_by("paid_for__name")
         )
+
+    @context
+    @property
+    def open_debts_per_person_qs(self) -> QuerySet[dict[str, object]]:
+        """Actual outstanding debts after optimisation, grouped by debtor and currency."""
+        return (
+            Debt.objects.filter(room_id=self.request.room.id, settled=False)
+            .values("debitor__name", "currency__sign")
+            .annotate(
+                debitor_name=F("debitor__name"),
+                currency_sign=F("currency__sign"),
+                total_open_debt=Sum("value"),
+            )
+            .order_by("debitor__name")
+        )
+
+    @context
+    @property
+    def max_open_debt_per_currency(self) -> dict[str, object]:
+        """Max open debt value per currency – used for bar scaling in the template."""
+        qs = (
+            Debt.objects.filter(room_id=self.request.room.id, settled=False)
+            .values("currency__sign")
+            .annotate(currency_sign=F("currency__sign"), max_debt=Max("value"))
+        )
+        return {row["currency_sign"]: row["max_debt"] for row in qs}

--- a/apps/debt/views/money_spent_on_room_view/money_spent_on_room_view.py
+++ b/apps/debt/views/money_spent_on_room_view/money_spent_on_room_view.py
@@ -47,6 +47,7 @@ class MoneySpentOnRoomView(RoomChildTransactionQuerysetMixin, DebtBaseContext, g
                 currency_sign=F("parent_transaction__currency__sign"),
                 total_covered_for_person=Sum("value"),
             )
+            .filter(total_covered_for_person__gt=0)
             .order_by("paid_for__name")
         )
 
@@ -68,7 +69,7 @@ class MoneySpentOnRoomView(RoomChildTransactionQuerysetMixin, DebtBaseContext, g
     @context
     @property
     def max_open_debt_per_currency(self) -> dict[str, object]:
-        """Max open debt value per currency – used for bar scaling in the template."""
+        """Max open debt value per currency - used for bar scaling in the template."""
         qs = (
             Debt.objects.filter(room_id=self.request.room.id, settled=False)
             .values("currency__sign")

--- a/apps/locale/de/LC_MESSAGES/django.po
+++ b/apps/locale/de/LC_MESSAGES/django.po
@@ -2,6 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yamsa\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-24 09:28+0200\n"
 "PO-Revision-Date: 2025-01-01 00:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -11,266 +12,399 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: apps/account/forms/change_password_form.py:11
 msgid "Your current password is incorrect"
 msgstr "Dein aktuelles Passwort ist falsch"
 
+#: apps/account/forms/change_password_form.py:12
 msgid "Passwords do not match"
 msgstr "Passwörter stimmen nicht überein"
 
+#: apps/account/forms/change_password_form.py:16
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
+#: apps/account/forms/change_password_form.py:17
 msgid "Your new password"
 msgstr "Dein neues Passwort"
 
+#: apps/account/forms/change_password_form.py:18
 msgid "Confirm your new password"
 msgstr "Bestätige dein neues Passwort"
 
+#: apps/account/forms/edit_user_form.py:12
 msgid "We could not read that file. Please upload a valid image."
-msgstr "Wir konnten diese Datei nicht lesen. Bitte lade ein gültiges Bild hoch."
+msgstr ""
+"Wir konnten diese Datei nicht lesen. Bitte lade ein gültiges Bild hoch."
 
+#: apps/account/forms/edit_user_form.py:13
 msgid "The profile picture could not be reduced enough. Try a smaller file."
-msgstr "Das Profilbild konnte nicht ausreichend verkleinert werden. Versuche es mit einer kleineren Datei."
+msgstr ""
+"Das Profilbild konnte nicht ausreichend verkleinert werden. Versuche es mit "
+"einer kleineren Datei."
 
+#: apps/account/forms/edit_user_form.py:32
 msgid "Receive push notifications"
 msgstr "Push-Benachrichtigungen erhalten"
 
+#: apps/account/forms/edit_user_form.py:33
+#: apps/account/templates/account/detail.html:77
 msgid "Preferred language"
 msgstr "Bevorzugte Sprache"
 
+#: apps/account/forms/edit_user_form.py:34
 msgid "Receive payment reminder emails"
 msgstr "E-Mail-Erinnerungen an Zahlungen erhalten"
 
+#: apps/account/forms/edit_user_form.py:35
 msgid "Receive room reminder emails"
 msgstr "E-Mail-Erinnerungen zum Raum erhalten"
 
+#: apps/account/forms/guest_send_invitation_form.py:10
 #, python-brace-format
 msgid "User with email address '{email}' already exists"
 msgstr "Benutzer:in mit der E-Mail-Adresse '{email}' existiert bereits"
 
+#: apps/account/forms/register_form.py:12
 #, python-brace-format
 msgid "The email address '{email}' is already in use"
 msgstr "Die E-Mail-Adresse '{email}' wird bereits verwendet"
 
+#: apps/account/forms/user_forgot_password_form.py:10
 #, python-brace-format
 msgid "The email address '{email}' is not registered with yamsa"
 msgstr "Die E-Mail-Adresse '{email}' ist nicht bei yamsa registriert"
 
+#: apps/account/forms/user_forgot_password_form.py:13
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:21
 msgid "Email"
 msgstr "E-Mail"
 
+#: apps/account/forms/user_forgot_password_form.py:14
 msgid "Email your account is linked to"
 msgstr "E-Mail-Adresse, mit der dein Konto verknüpft ist"
 
+#: apps/account/models/user.py:71
 msgid "Staff Status"
 msgstr "Status der Mitarbeitenden"
 
+#: apps/account/models/user.py:73
 msgid "Designates whether the user can log into this admin site."
 msgstr "Legt fest, ob Benutzer:innen sich im Adminbereich anmelden kann."
 
+#: apps/account/models/user.py:88
 msgid "User"
 msgstr "Benutzer:in"
 
+#: apps/account/models/user.py:89
 msgid "Users"
 msgstr "Benutzer:innen"
 
+#: apps/account/models/user_friendship.py:12
 msgid "User friendship"
 msgstr "Benutzer:innenfreundschaft"
 
+#: apps/account/models/user_friendship.py:13
 msgid "User friendships"
 msgstr "Benutzer:innenfreundschaften"
 
+#: apps/account/models/user_friendship.py:34
 msgid "Users cannot be friends with themselves."
 msgstr "Benutzer:innen können nicht mit sich selbst befreundet sein."
 
+#: apps/account/templates/account/change_password.html:9
 msgid "Change your password:"
 msgstr "Ändere dein Passwort:"
 
+#: apps/account/templates/account/change_password.html:18
+#: apps/room/templates/room/edit.html:36
 msgid "Save"
 msgstr "Speichern"
 
+#: apps/account/templates/account/change_password.html:24
 msgid "Note:"
 msgstr "Achtung:"
 
-msgid "After a successful password change, you will be prompted to login again."
-msgstr "Nach einer erfolgreichen Passwortänderung wirst du aufgefordert, dich erneut anzumelden."
+#: apps/account/templates/account/change_password.html:24
+msgid ""
+"After a successful password change, you will be prompted to login again."
+msgstr ""
+"Nach einer erfolgreichen Passwortänderung wirst du aufgefordert, dich erneut "
+"anzumelden."
 
+#: apps/account/templates/account/create_guest.html:6
 #, python-format
 msgid "Invite a guest to \"%(room)s\""
 msgstr "Gast zu \"%(room)s\" einladen"
 
+#: apps/account/templates/account/create_guest.html:7
+#: apps/account/templates/account/create_guest.html:8
+#: apps/account/templates/account/list.html:218
+#: apps/account/templates/account/list.html:230
+#: apps/room/templates/room/partials/_detail_who_are_you.html:8
 msgid "Guest access"
 msgstr "Gastzugang"
 
+#: apps/account/templates/account/create_guest.html:9
 msgid "Perfect for roommates without accounts - give them lightweight access."
 msgstr "Perfekt für Mitbewohner ohne Konto - gib ihnen leichten Zugang."
 
+#: apps/account/templates/account/create_guest.html:10
 msgid "Guest pass"
 msgstr "Gastpass"
 
+#: apps/account/templates/account/create_guest.html:11
 msgid "Guest name"
 msgstr "Gastname"
 
+#: apps/account/templates/account/create_guest.html:12
 msgid "e.g. Alex from the kitchen"
 msgstr "z. B. Alex aus der Küche"
 
+#: apps/account/templates/account/create_guest.html:13
 msgid "Guests can later convert to full accounts without losing history."
-msgstr "Gäste können später in vollständige Konten konvertieren, ohne ihre Historie zu verlieren."
+msgstr ""
+"Gäste können später in vollständige Konten konvertieren, ohne ihre Historie "
+"zu verlieren."
 
+#: apps/account/templates/account/create_guest.html:14
 msgid "We'll drop them right into this room."
 msgstr "Wir setzen sie direkt in diesen Raum."
 
+#: apps/account/templates/account/create_guest.html:15
+#: apps/account/templates/account/list.html:192
 msgid "Add guest"
 msgstr "Gast hinzufügen"
 
+#: apps/account/templates/account/create_guest.html:16
 msgid "Back to people"
 msgstr "Zurück zur Personenliste"
 
+#: apps/account/templates/account/detail.html:11
 msgid "Guest Mode"
 msgstr "Gastmodus"
 
+#: apps/account/templates/account/detail.html:14
 #, python-format
 msgid "Hi %(user.name)s"
 msgstr "Hallo %(user.name)s"
 
-msgid "Thanks for hopping into a room as a guest. Unlock reminders, push notifications, and richer history once you create a full account."
-msgstr "Danke, dass du als Gast einem Raum beigetreten bist. Schalte Erinnerungen, Push-Benachrichtigungen und ausführlichere Historie frei, sobald du ein vollständiges Konto erstellst."
+#: apps/account/templates/account/detail.html:20
+msgid ""
+"Thanks for hopping into a room as a guest. Unlock reminders, push "
+"notifications, and richer history once you create a full account."
+msgstr ""
+"Danke, dass du als Gast einem Raum beigetreten bist. Schalte Erinnerungen, "
+"Push-Benachrichtigungen und ausführlichere Historie frei, sobald du ein "
+"vollständiges Konto erstellst."
 
+#: apps/account/templates/account/detail.html:23
+#: apps/room/templates/room/partials/_detail_who_are_you.html:35
 msgid "Create a free account"
 msgstr "Kostenloses Konto erstellen"
 
+#: apps/account/templates/account/detail.html:25
 msgid "I already have an account"
 msgstr "Ich habe bereits ein Konto"
 
+#: apps/account/templates/account/detail.html:28
 msgid "Not you?"
 msgstr "Nicht du?"
 
+#: apps/account/templates/account/detail.html:28
 msgid "Log out instead"
 msgstr "Stattdessen abmelden"
 
+#: apps/account/templates/account/detail.html:42
 msgid "Admin"
 msgstr "Administrator"
 
+#: apps/account/templates/account/detail.html:69
 msgid "Your account overview"
 msgstr "Deine Kontenübersicht"
 
+#: apps/account/templates/account/detail.html:71
 msgid "Member profile"
 msgstr "Mitgliederprofil"
 
+#: apps/account/templates/account/detail.html:78
 msgid "Not set"
 msgstr "Nicht gesetzt"
 
+#: apps/account/templates/account/detail.html:82
 msgid "Superuser"
 msgstr "Superuser"
 
+#: apps/account/templates/account/detail.html:85
 msgid "Staff"
 msgstr "Mitarbeitende"
 
+#: apps/account/templates/account/detail.html:89
 msgid "PayPal linked"
 msgstr "PayPal verknüpft"
 
+#: apps/account/templates/account/detail.html:91
 msgid "No PayPal link"
 msgstr "Kein PayPal-Link"
 
+#: apps/account/templates/account/detail.html:105
+#: apps/account/templates/account/edit.html:19
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
+#: apps/account/templates/account/detail.html:117
 msgid "Display name"
 msgstr "Anzeigename"
 
+#: apps/account/templates/account/detail.html:123
+#: apps/account/templates/account/forgot_password.html:41
+#: apps/account/templates/account/login.html:44
+#: apps/account/templates/account/register.html:54
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
+#: apps/account/templates/account/detail.html:129
 msgid "PayPal.me username"
 msgstr "PayPal.me-Benutzername"
 
+#: apps/account/templates/account/detail.html:133
 msgid "No PayPal link yet"
 msgstr "Noch kein PayPal-Link"
 
+#: apps/account/templates/account/detail.html:141
 msgid "Push notifications"
 msgstr "Push-Benachrichtigungen"
 
+#: apps/account/templates/account/detail.html:144
+#: apps/account/templates/account/detail.html:167
 msgid "Enabled"
 msgstr "Aktiviert"
 
+#: apps/account/templates/account/detail.html:146
+#: apps/account/templates/account/detail.html:169
 msgid "Disabled"
 msgstr "Deaktiviert"
 
+#: apps/account/templates/account/detail.html:149
 msgid "Manage this toggle from the edit screen."
 msgstr "Verwalte diesen Schalter im Bearbeitungsbildschirm."
 
+#: apps/account/templates/account/detail.html:164
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:4
 msgid "Payment reminders"
 msgstr "Zahlungserinnerungen"
 
+#: apps/account/templates/account/detail.html:172
 msgid "Toggle this in the notifications center or via the email footer."
-msgstr "Schalte dies im Benachrichtigungszentrum oder über die Fußzeile der E-Mail um."
+msgstr ""
+"Schalte dies im Benachrichtigungszentrum oder über die Fußzeile der E-Mail "
+"um."
 
+#: apps/account/templates/account/detail.html:189
+#: apps/account/templates/account/edit.html:188
 msgid "Security"
 msgstr "Sicherheit"
 
+#: apps/account/templates/account/detail.html:190
 msgid "Change your password"
 msgstr "Ändere dein Passwort"
 
+#: apps/account/templates/account/detail.html:191
 msgid "Choose a unique password to keep your rooms safe."
 msgstr "Wähle ein einzigartiges Passwort, um deine Räume zu schützen."
 
+#: apps/account/templates/account/detail.html:200
+#: apps/account/templates/account/edit.html:201
 msgid "Change password"
 msgstr "Passwort ändern"
 
+#: apps/account/templates/account/edit.html:20
 msgid "Keep your details up to date"
 msgstr "Halte deine Daten aktuell"
 
+#: apps/account/templates/account/edit.html:29
+#: apps/room/templates/room/edit.html:237
+#: apps/transaction/templates/transaction/create.html:259
 msgid "Cancel"
 msgstr "Abbrechen"
 
+#: apps/account/templates/account/edit.html:32
+#: apps/transaction/templates/transaction/edit.html:324
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
+#: apps/account/templates/account/edit.html:42
 msgid "Profile picture preview"
 msgstr "Vorschau des Profilbilds"
 
+#: apps/account/templates/account/edit.html:54
 msgid "Profile photo"
 msgstr "Profilfoto"
 
-msgid "We automatically resize and compress PNG/JPEG uploads so they stay under 3 MB."
-msgstr "Wir ändern automatisch die Größe und komprimieren PNG-/JPEG-Uploads, damit sie unter 3 MB bleiben."
+#: apps/account/templates/account/edit.html:65
+msgid ""
+"We automatically resize and compress PNG/JPEG uploads so they stay under 3 "
+"MB."
+msgstr ""
+"Wir ändern automatisch die Größe und komprimieren PNG-/JPEG-Uploads, damit "
+"sie unter 3 MB bleiben."
 
+#: apps/account/templates/account/edit.html:73
 msgid "Remove your profile picture?"
 msgstr "Profilbild entfernen?"
 
+#: apps/account/templates/account/edit.html:76
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
+#: apps/account/templates/account/edit.html:138
 msgid "Notification Center"
 msgstr "Benachrichtigungszentrum"
 
+#: apps/account/templates/account/edit.html:139
 msgid "Choose how you want to hear from us."
 msgstr "Wähle, wie du von uns hören möchtest."
 
+#: apps/account/templates/account/edit.html:189
 msgid "Need a new password?"
 msgstr "Neues Passwort benötigt?"
 
-msgid "Set a fresh password any time. We’ll keep you logged in while you update it."
-msgstr "Lege jederzeit ein neues Passwort fest. Wir halten dich während der Aktualisierung angemeldet."
+#: apps/account/templates/account/edit.html:191
+msgid ""
+"Set a fresh password any time. We’ll keep you logged in while you update it."
+msgstr ""
+"Lege jederzeit ein neues Passwort fest. Wir halten dich während der "
+"Aktualisierung angemeldet."
 
+#: apps/account/templates/account/forgot_password.html:12
+#: apps/account/templates/account/forgot_password.html:38
 msgid "Forgot password"
 msgstr "Passwort vergessen"
 
+#: apps/account/templates/account/forgot_password.html:13
 msgid "We'll send you a recovery link"
 msgstr "Wir senden dir einen Wiederherstellungslink"
 
-msgid "Tell us which email address is linked to your account and we’ll do the rest."
-msgstr "Sag uns, welche E-Mail-Adresse mit deinem Konto verknüpft ist, und wir übernehmen den Rest."
+#: apps/account/templates/account/forgot_password.html:15
+msgid ""
+"Tell us which email address is linked to your account and we’ll do the rest."
+msgstr ""
+"Sag uns, welche E-Mail-Adresse mit deinem Konto verknüpft ist, und wir "
+"übernehmen den Rest."
 
+#: apps/account/templates/account/forgot_password.html:24
 msgid "Back to login"
 msgstr "Zurück zur Anmeldung"
 
+#: apps/account/templates/account/forgot_password.html:37
 msgid "Need to reset your password?"
 msgstr "Möchtest du dein Passwort zurücksetzen?"
 
+#: apps/account/templates/account/forgot_password.html:48
 msgid "Request a new password"
 msgstr "Neues Passwort anfordern"
 
+#: apps/account/templates/account/invite_guest.html:8
 #, python-format
 msgid ""
 "\n"
@@ -281,208 +415,325 @@ msgstr ""
 "                    Lade %(invitee)s zu \"%(room)s\" ein\n"
 "                "
 
+#: apps/account/templates/account/invite_guest.html:34
 msgid "Send invite"
 msgstr "Einladung senden"
 
+#: apps/account/templates/account/list.html:146
 msgid "Room roster"
 msgstr "Raumteilnehmerliste"
 
+#: apps/account/templates/account/list.html:149
 #, python-format
 msgid "Everyone in %(room_name)s"
 msgstr "Alle in %(room_name)s"
 
-msgid "Invite roommates, add guests, and keep tabs on who has already viewed the room."
-msgstr "Lade Mitbewohner ein, füge Gäste hinzu und behalte im Blick, wer den Raum bereits angesehen hat."
+#: apps/account/templates/account/list.html:152
+msgid ""
+"Invite roommates, add guests, and keep tabs on who has already viewed the "
+"room."
+msgstr ""
+"Lade Mitbewohner ein, füge Gäste hinzu und behalte im Blick, wer den Raum "
+"bereits angesehen hat."
 
+#: apps/account/templates/account/list.html:155
+#: apps/transaction/templates/transaction/list.html:256
 msgid "Status"
 msgstr "Status"
 
+#: apps/account/templates/account/list.html:158
 msgid "Room closed"
 msgstr "Raum geschlossen"
 
+#: apps/account/templates/account/list.html:160
 msgid "Room open"
 msgstr "Raum geöffnet"
 
+#: apps/account/templates/account/list.html:177
 msgid "Add existing user"
 msgstr "Bestehenden Nutzer hinzufügen"
 
+#: apps/account/templates/account/list.html:207
 msgid "No one here yet"
 msgstr "Noch niemand hier"
 
+#: apps/account/templates/account/list.html:208
 msgid "Invite a roommate or add a guest to start splitting expenses."
-msgstr "Lade einen Mitbewohner ein oder füge einen Gast hinzu, um mit dem Aufteilen der Ausgaben zu beginnen."
+msgstr ""
+"Lade einen Mitbewohner ein oder füge einen Gast hinzu, um mit dem Aufteilen "
+"der Ausgaben zu beginnen."
 
+#: apps/account/templates/account/list.html:221
 #, python-format
 msgid "Limited view of %(room_name)s"
 msgstr "Eingeschränkte Ansicht von %(room_name)s"
 
-msgid "Room members keep the roster private. Join the room to see who helps run this space."
-msgstr "Die Mitglieder des Raums halten die Mitgliederliste geheim. Tritt dem Raum bei, um zu sehen, wer diesen Raum mitbetreut."
+#: apps/account/templates/account/list.html:224
+msgid ""
+"Room members keep the roster private. Join the room to see who helps run "
+"this space."
+msgstr ""
+"Die Mitglieder des Raums halten die Mitgliederliste geheim. Tritt dem Raum "
+"bei, um zu sehen, wer diesen Raum mitbetreut."
 
+#: apps/account/templates/account/list.html:231
 msgid "Request access or register to interact with this room."
-msgstr "Frage Zugang an oder registriere dich, um mit diesem Raum zu interagieren."
+msgstr ""
+"Frage Zugang an oder registriere dich, um mit diesem Raum zu interagieren."
 
+#: apps/account/templates/account/login.html:12
 msgid "Welcome back"
 msgstr "Willkommen zurück"
 
+#: apps/account/templates/account/login.html:13
 msgid "Keep your shared finances moving"
 msgstr "Halte eure gemeinsamen Finanzen in Bewegung"
 
-msgid "Stay in the flow: avoid surprising logouts and finish your next journal in one session."
-msgstr "Bleib im Fluss: Vermeide überraschende Abmeldungen und beende dein nächstes Journal in einer Sitzung."
+#: apps/account/templates/account/login.html:15
+msgid ""
+"Stay in the flow: avoid surprising logouts and finish your next journal in "
+"one session."
+msgstr ""
+"Bleib im Fluss: Vermeide überraschende Abmeldungen und beende dein nächstes "
+"Journal in einer Sitzung."
 
+#: apps/account/templates/account/login.html:24
 msgid "Create an account"
 msgstr "Konto erstellen"
 
+#: apps/account/templates/account/login.html:37
 msgid "Secure login"
 msgstr "Sichere Anmeldung"
 
+#: apps/account/templates/account/login.html:38
 msgid "Login"
 msgstr "Anmelden"
 
+#: apps/account/templates/account/login.html:49
 msgid "Password"
 msgstr "Passwort"
 
+#: apps/account/templates/account/login.html:56
 msgid "Stay signed in for 30 days"
 msgstr "Für 30 Tage angemeldet bleiben"
 
+#: apps/account/templates/account/login.html:58
 msgid "Your session stays active as long as you keep using the app."
 msgstr "Deine Sitzung bleibt aktiv, solange du die App weiter nutzt."
 
+#: apps/account/templates/account/login.html:67
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
+#: apps/account/templates/account/login.html:72
 msgid "Log in"
 msgstr "Anmelden"
 
-msgid "We renew your cookie while you stay active so normal usage does not log you out, and checking \"Stay signed in\" keeps you signed in for 30 days."
-msgstr "Wir erneuern dein Cookie, solange du aktiv bleibst, damit dich normale Nutzung nicht abmeldet, und mit aktivierter Option \"Angemeldet bleiben\" bleibst du 30 Tage angemeldet."
+#: apps/account/templates/account/login.html:74
+msgid ""
+"We renew your cookie while you stay active so normal usage does not log you "
+"out, and checking \"Stay signed in\" keeps you signed in for 30 days."
+msgstr ""
+"Wir erneuern dein Cookie, solange du aktiv bleibst, damit dich normale "
+"Nutzung nicht abmeldet, und mit aktivierter Option \"Angemeldet bleiben\" "
+"bleibst du 30 Tage angemeldet."
 
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:13
 msgid "Unsubscribed"
 msgstr "Abgemeldet"
 
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:14
 msgid "You’re no longer receiving payment reminders."
 msgstr "Du erhältst keine Zahlungserinnerungen mehr."
 
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:16
 msgid "Oops"
 msgstr "Hoppla"
 
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:17
 msgid "We couldn’t process the unsubscribe."
 msgstr "Wir konnten die Abmeldung nicht verarbeiten."
 
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:24
+#: apps/templates/_side_menu.html:122
 msgid "Sign in"
 msgstr "Anmelden"
 
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:27
 msgid "Account settings"
 msgstr "Kontoeinstellungen"
 
+#: apps/account/templates/account/payment_reminder_unsubscribe.html:30
 msgid "You can always re-enable reminders from your notification settings."
-msgstr "Du kannst Erinnerungen jederzeit über deine Benachrichtigungseinstellungen wieder aktivieren."
+msgstr ""
+"Du kannst Erinnerungen jederzeit über deine Benachrichtigungseinstellungen "
+"wieder aktivieren."
 
+#: apps/account/templates/account/register.html:12
 msgid "Join yamsa"
 msgstr "yamsa beitreten"
 
+#: apps/account/templates/account/register.html:13
 msgid "Create shared clarity in your rooms"
 msgstr "Schaffe gemeinsame Klarheit in deinen Räumen"
 
-msgid "Registering takes a minute and keeps every room, bill, and settlement in sync."
-msgstr "Die Registrierung dauert eine Minute und hält jeden Raum, jede Rechnung und jede Abrechnung synchron."
+#: apps/account/templates/account/register.html:15
+msgid ""
+"Registering takes a minute and keeps every room, bill, and settlement in "
+"sync."
+msgstr ""
+"Die Registrierung dauert eine Minute und hält jeden Raum, jede Rechnung und "
+"jede Abrechnung synchron."
 
+#: apps/account/templates/account/register.html:19
+#: apps/room/templates/room/partials/_detail_who_are_you.html:36
 msgid "Already have an account?"
 msgstr "Bereits ein Konto?"
 
+#: apps/account/templates/account/register.html:25
 msgid "Login here!"
 msgstr "Hier anmelden!"
 
+#: apps/account/templates/account/register.html:38
 msgid "Start now"
 msgstr "Jetzt anfangen"
 
+#: apps/account/templates/account/register.html:39
 msgid "Register"
 msgstr "Registrieren"
 
+#: apps/account/templates/account/register.html:42
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:20
 msgid "Name"
 msgstr "Name"
 
+#: apps/account/templates/account/register.html:68
 msgid "User ID"
 msgstr "Benutzer-ID"
 
+#: apps/account/templates/account/register.html:76
 msgid "Is Guest"
 msgstr "Ist Gast"
 
+#: apps/account/templates/account/register.html:85
 msgid "Register now"
 msgstr "Jetzt registrieren"
 
+#: apps/account/views/user_login_view.py:18
 msgid "The combination of email and password does not match"
 msgstr "Die Kombination aus E-Mail und Passwort ist nicht korrekt"
 
+#: apps/config/settings.py:89
 msgid "English"
 msgstr "Englisch"
 
+#: apps/config/settings.py:90
 msgid "German"
 msgstr "Deutsch"
 
+#: apps/core/templates/core/_welcome.html:10
 msgid "Room activity timeline"
 msgstr "Aktivitätsverlauf des Raums"
 
+#: apps/core/templates/core/_welcome.html:11
 msgid "See transactions and changes at a glance"
 msgstr "Transaktionen und Änderungen auf einen Blick sehen"
 
-msgid "Every room update - expenses logged, settlements, highlights - lands here so you never miss a beat."
-msgstr "Jedes Raum-Update – erfasste Ausgaben, Abrechnungen, Highlights – landet hier, damit du nichts verpasst."
+#: apps/core/templates/core/_welcome.html:13
+msgid ""
+"Every room update - expenses logged, settlements, highlights - lands here so "
+"you never miss a beat."
+msgstr ""
+"Jedes Raum-Update – erfasste Ausgaben, Abrechnungen, Highlights – landet "
+"hier, damit du nichts verpasst."
 
+#: apps/core/templates/core/_welcome.html:17
 msgid "Auto-updated feed"
 msgstr "Automatisch aktualisierter Feed"
 
+#: apps/core/templates/core/_welcome.html:18
 msgid "Events appear in chronological order with the newest at the top."
-msgstr "Ereignisse erscheinen in chronologischer Reihenfolge, die Neuesten oben."
+msgstr ""
+"Ereignisse erscheinen in chronologischer Reihenfolge, die Neuesten oben."
 
+#: apps/core/templates/core/_welcome.html:31
 msgid "No updates yet"
 msgstr "Noch keine Aktualisierungen"
 
-msgid "Once roommates start logging expenses or changes, they will appear here."
-msgstr "Sobald Mitbewohner Ausgaben oder Änderungen erfassen, erscheinen sie hier."
+#: apps/core/templates/core/_welcome.html:32
+msgid ""
+"Once roommates start logging expenses or changes, they will appear here."
+msgstr ""
+"Sobald Mitbewohner Ausgaben oder Änderungen erfassen, erscheinen sie hier."
 
-msgid "yamsa helps shared households track expenses, settle debts, and stay organized with collaborative rooms, dashboards, and notifications."
-msgstr "yamsa hilft Wohngemeinschaften dabei, Ausgaben zu verfolgen, Schulden auszugleichen und mit kollaborativen Räumen, Dashboards und Benachrichtigungen organisiert zu bleiben."
+#: apps/core/templates/core/base.html:5
+msgid ""
+"yamsa helps shared households track expenses, settle debts, and stay "
+"organized with collaborative rooms, dashboards, and notifications."
+msgstr ""
+"yamsa hilft Wohngemeinschaften dabei, Ausgaben zu verfolgen, Schulden "
+"auszugleichen und mit kollaborativen Räumen, Dashboards und "
+"Benachrichtigungen organisiert zu bleiben."
 
+#: apps/core/templates/core/base.html:6
 msgid "yamsa, shared expenses, roommate app, bill splitting, dashboards"
-msgstr "yamsa, gemeinsame Ausgaben, Mitbewohner-App, Rechnungsteilung, Dashboards"
+msgstr ""
+"yamsa, gemeinsame Ausgaben, Mitbewohner-App, Rechnungsteilung, Dashboards"
 
+#: apps/core/templates/core/base.html:18
 msgid "yamsa"
 msgstr "yamsa"
 
+#: apps/currency/models.py:13 apps/debt/views/debt_export_view.py:16
+#: apps/transaction/templates/transaction/create.html:176
+#: apps/transaction/templates/transaction/edit.html:128
+#: apps/transaction/views/transaction_export_view.py:17
 msgid "Currency"
 msgstr "Währung"
 
+#: apps/currency/models.py:14
 msgid "Currencies"
 msgstr "Währungen"
 
+#: apps/debt/models/debt.py:35
 #, python-brace-format
 msgid "Settled: {debitor} owes {value}{currency} to {creditor}"
 msgstr "Beglichen: {debitor} schuldet {value}{currency} an {creditor}"
 
+#: apps/debt/models/debt.py:37
 #, python-brace-format
 msgid "{debitor} owes {value}{currency} to {creditor}"
 msgstr "{debitor} schuldet {value}{currency} an {creditor}"
 
+#: apps/debt/models/reminder_log.py:10
 msgid "Inactive debt reminder"
 msgstr "Erinnerung für inaktive Schulden"
 
+#: apps/debt/models/reminder_log.py:11
 msgid "Inactive room reminder"
 msgstr "Erinnerung für inaktiven Raum"
 
+#: apps/debt/models/reminder_log.py:21
 msgid "Reminder log"
 msgstr "Erinnerungsprotokoll"
 
+#: apps/debt/models/reminder_log.py:22
 msgid "Reminder logs"
 msgstr "Erinnerungsprotokolle"
 
+#: apps/debt/templates/debt/list.html:40
 msgid "Optimised debts"
 msgstr "Optimierte Schulden"
 
-msgid "Track what is left to settle inside this room. Click the piggy-bank to mark a debt as paid."
-msgstr "Verfolge, was in diesem Raum noch ausgeglichen werden muss. Klicke auf das Sparschwein, um eine Schuld als bezahlt zu markieren."
+#: apps/debt/templates/debt/list.html:42
+msgid ""
+"Track what is left to settle inside this room. Click the piggy-bank to mark "
+"a debt as paid."
+msgstr ""
+"Verfolge, was in diesem Raum noch ausgeglichen werden muss. Klicke auf das "
+"Sparschwein, um eine Schuld als bezahlt zu markieren."
 
+#: apps/debt/templates/debt/list.html:48
 #, python-format
 msgid ""
 "\n"
@@ -501,47 +752,65 @@ msgstr[1] ""
 "                        %(active_debt_count)s ausstehende Schulden\n"
 "                    "
 
+#: apps/debt/templates/debt/list.html:60 apps/debt/templates/debt/list.html:62
+#: apps/transaction/templates/transaction/list.html:295
+#: apps/transaction/templates/transaction/list.html:297
 msgid "Export CSV"
 msgstr "CSV exportieren"
 
+#: apps/debt/templates/debt/list.html:66
 msgid "View category breakdown"
 msgstr "Kategorienaufteilung anzeigen"
 
+#: apps/debt/templates/debt/list.html:73
 msgid "Break down spend"
 msgstr "Ausgaben aufschlüsseln"
 
+#: apps/debt/templates/debt/list.html:89
 msgid "Money overview"
 msgstr "Geldübersicht"
 
+#: apps/debt/templates/debt/list.html:90
 msgid "See how much each person has paid and who still owes what."
 msgstr "Sieh, wie viel jede Person bezahlt hat und wer noch was schuldet."
 
+#: apps/debt/templates/debt/list.html:104
 #, python-format
 msgid "%(debitor_display)s owes %(value)s%(currency)s to %(creditor_display)s"
-msgstr "%(debitor_display)s schuldet %(value)s%(currency)s an %(creditor_display)s"
+msgstr ""
+"%(debitor_display)s schuldet %(value)s%(currency)s an %(creditor_display)s"
 
+#: apps/debt/templates/debt/list.html:111
 #, python-format
 msgid "Settled on %(settled_at)s"
 msgstr "Am %(settled_at)s beglichen"
 
+#: apps/debt/templates/debt/list.html:116
 msgid "Tap the piggy-bank when this debt is paid off."
 msgstr "Tippe auf das Sparschwein, wenn diese Schuld beglichen ist."
 
+#: apps/debt/templates/debt/list.html:121
 msgid "Settled"
 msgstr "Beglichen"
 
+#: apps/debt/templates/debt/list.html:123
 msgid "Outstanding"
 msgstr "Ausstehend"
 
+#: apps/debt/templates/debt/list.html:131
+#: apps/debt/tests/test_views/test_debt_list_view.py:84
 msgid "No debts yet"
 msgstr "Noch keine Schulden"
 
+#: apps/debt/templates/debt/list.html:132
 msgid "As expenses are added, we will surface who owes whom here."
 msgstr "Wenn Ausgaben hinzukommen, zeigen wir hier, wer wem etwas schuldet."
 
+#: apps/debt/templates/debt/partials/_settle_debt_piggy_icon.html:19
 msgid "This transaction is not yours to settle!"
 msgstr "Diese Transaktion darfst du nicht ausgleichen!"
 
+#: apps/debt/templates/debt/settle.html:7
 #, python-format
 msgid ""
 "\n"
@@ -552,563 +821,842 @@ msgstr ""
 "                    Deine Schuld an %(creditor_name)s\n"
 "                "
 
+#: apps/debt/templates/debt/settle.html:12
 #, python-format
 msgid ""
 "\n"
-"                    Are you sure that you have settled your debt (%(debt_value)s%(debt_currency)s)\n"
+"                    Are you sure that you have settled your debt "
+"(%(debt_value)s%(debt_currency)s)\n"
 "                    to %(creditor_name)s?\n"
 "                "
 msgstr ""
 "\n"
-"                    Bist du sicher, dass du deine Schuld (%(debt_value)s%(debt_currency)s)\n"
+"                    Bist du sicher, dass du deine Schuld "
+"(%(debt_value)s%(debt_currency)s)\n"
 "                    bei %(creditor_name)s beglichen hast?\n"
 "                "
 
+#: apps/debt/templates/debt/settle.html:28
 msgid "Debt ID"
 msgstr "Schulden-ID"
 
+#: apps/debt/templates/debt/settle.html:37
 msgid "Settled?"
 msgstr "Beglichen?"
 
+#: apps/debt/templates/debt/settle.html:52
 msgid "No, take me to their paypal"
 msgstr "Nein, bring mich zu ihrem PayPal"
 
+#: apps/debt/templates/debt/settle.html:61
 msgid "No action available"
 msgstr "Keine Aktion möglich"
 
+#: apps/debt/templates/debt/settle.html:61
 msgid "No"
 msgstr "Nein"
 
+#: apps/debt/templates/debt/settle.html:65
 msgid "Yes"
 msgstr "Ja"
 
+#: apps/debt/views/debt_export_view.py:16
 msgid "Debitor"
 msgstr "Schuldner"
 
+#: apps/debt/views/debt_export_view.py:16
 msgid "Creditor"
 msgstr "Gläubiger"
 
+#: apps/debt/views/debt_export_view.py:16
+#: apps/transaction/templates/transaction/child_transaction_create.html:5
+#: apps/transaction/templates/transaction/edit.html:226
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:17
+#: apps/transaction/views/transaction_export_view.py:17
 msgid "Amount"
 msgstr "Betrag"
 
+#: apps/debt/views/debt_export_view.py:28
 msgid "debts"
 msgstr "schulden"
 
+#: apps/mail/services/base_email_service/email_base_text_context.py:13
 msgid "yamsa | Yet another money split app"
 msgstr "yamsa | Noch eine App zum Geldteilen"
 
+#: apps/mail/services/base_email_service/email_user_text_context.py:10
 msgid "Hey"
 msgstr "Hey"
 
+#: apps/mail/services/forgot_password_mail_service.py:9
 msgid "New Password"
 msgstr "Neues Passwort"
 
+#: apps/mail/services/forgot_password_mail_service.py:14
 msgid "Log in with new password"
 msgstr "Mit neuem Passwort anmelden"
 
+#: apps/mail/services/forgot_password_mail_service.py:21
 msgid "Forgotten your password?"
 msgstr "Passwort vergessen?"
 
+#: apps/mail/services/forgot_password_mail_service.py:22
 msgid "No worries - happens to the best!"
 msgstr "Keine Sorge – passiert den Besten!"
 
+#: apps/mail/services/forgot_password_mail_service.py:24
 msgid "Your new password is:"
 msgstr "Dein neues Passwort lautet:"
 
+#: apps/mail/services/forgot_password_mail_service.py:27
 msgid "Log in with your new password, by clicking the button below"
-msgstr "Melde dich mit deinem neuen Passwort an, indem du auf den Button unten klickst"
+msgstr ""
+"Melde dich mit deinem neuen Passwort an, indem du auf den Button unten "
+"klickst"
 
+#: apps/mail/services/forgot_password_mail_service.py:28
 msgid "(And don't forget to change your password afterwards!)"
 msgstr "(Und vergiss nicht, dein Passwort danach zu ändern!)"
 
+#: apps/mail/services/invitation_mail_service.py:12
 msgid "Invitation"
 msgstr "Einladung"
 
+#: apps/mail/services/invitation_mail_service.py:21
 #, python-format
 msgid "You have been invited by %(inviter)s to join your friends on yamsa"
-msgstr "Du wurdest von %(inviter)s eingeladen, dich deinen Freunden auf yamsa anzuschließen"
+msgstr ""
+"Du wurdest von %(inviter)s eingeladen, dich deinen Freunden auf yamsa "
+"anzuschließen"
 
+#: apps/mail/services/invitation_mail_service.py:26
 msgid "Click the button below to register!"
 msgstr "Klicke auf den Button unten, um dich zu registrieren!"
 
+#: apps/mail/services/invitation_mail_service.py:34
 msgid "Register here"
 msgstr "Hier registrieren"
 
+#: apps/mail/services/payment_reminder_mail_service.py:24
 #, python-format
 msgid "%(room_name)s | Payment reminder"
 msgstr "%(room_name)s | Zahlungserinnerung"
 
+#: apps/mail/services/payment_reminder_mail_service.py:30
 #, python-format
-msgid "Hey there! It has been %(inactivity_days)d days since any activity in %(room_name)s."
-msgstr "Hallo! Es sind %(inactivity_days)d Tage seit der letzten Aktivität in %(room_name)s vergangen."
+msgid ""
+"Hey there! It has been %(inactivity_days)d days since any activity in "
+"%(room_name)s."
+msgstr ""
+"Hallo! Es sind %(inactivity_days)d Tage seit der letzten Aktivität in "
+"%(room_name)s vergangen."
 
+#: apps/mail/services/payment_reminder_mail_service.py:35
 #, python-format
 msgid "You currently owe %(amount_summary)s."
 msgstr "Du schuldest aktuell %(amount_summary)s."
 
-msgid "Please follow the link below to review and settle the outstanding balance before it grows stale."
-msgstr "Bitte folge dem Link unten, um den offenen Betrag zu prüfen und zu begleichen, bevor er veraltet."
+#: apps/mail/services/payment_reminder_mail_service.py:39
+msgid ""
+"Please follow the link below to review and settle the outstanding balance "
+"before it grows stale."
+msgstr ""
+"Bitte folge dem Link unten, um den offenen Betrag zu prüfen und zu "
+"begleichen, bevor er veraltet."
 
+#: apps/mail/services/payment_reminder_mail_service.py:46
 #, python-format
 msgid "Payment reminder: %(room_name)s"
 msgstr "Zahlungserinnerung: %(room_name)s"
 
-msgid "This reminder is generated automatically for overdue balances. We're cheering for you!"
-msgstr "Diese Erinnerung wird automatisch bei überfälligen Beträgen erzeugt. Wir drücken dir die Daumen!"
+#: apps/mail/services/payment_reminder_mail_service.py:47
+msgid ""
+"This reminder is generated automatically for overdue balances. We're "
+"cheering for you!"
+msgstr ""
+"Diese Erinnerung wird automatisch bei überfälligen Beträgen erzeugt. Wir "
+"drücken dir die Daumen!"
 
+#: apps/mail/services/payment_reminder_mail_service.py:48
 msgid "Need a hand? Reach out to your room admin if the numbers look off."
-msgstr "Brauchst du Unterstützung? Wende dich an den Raum-Admin, wenn die Zahlen nicht stimmen."
+msgstr ""
+"Brauchst du Unterstützung? Wende dich an den Raum-Admin, wenn die Zahlen "
+"nicht stimmen."
 
+#: apps/mail/services/payment_reminder_mail_service.py:60
 msgid "Review pending debts"
 msgstr "Ausstehende Schulden prüfen"
 
+#: apps/mail/services/post_register_mail_service.py:10
+#: apps/mail/services/post_register_mail_service.py:20
 msgid "Welcome to yamsa"
 msgstr "Willkommen bei yamsa"
 
+#: apps/mail/services/post_register_mail_service.py:23
 msgid "It looks like you already belong to some rooms!"
 msgstr "Es sieht so aus, als würdest du bereits zu einigen Räumen gehören!"
 
+#: apps/mail/services/post_register_mail_service.py:24
 msgid "Check them out, by clicking the button below"
 msgstr "Schau sie dir an, indem du auf den Button unten klickst"
 
+#: apps/mail/services/post_register_mail_service.py:26
 msgid "Create a new room, by clicking the button below"
 msgstr "Erstelle einen neuen Raum, indem du auf den Button unten klickst"
 
+#: apps/mail/services/post_register_mail_service.py:32
 msgid "Create a room"
 msgstr "Einen Raum erstellen"
 
+#: apps/mail/services/post_register_mail_service.py:36
 msgid "See your rooms"
 msgstr "Deine Räume ansehen"
 
+#: apps/mail/services/room_closure_reminder_mail_service.py:23
 #, python-format
 msgid "%(room_name)s | Room still open?"
 msgstr "%(room_name)s | Raum noch offen?"
 
+#: apps/mail/services/room_closure_reminder_mail_service.py:29
 #, python-format
 msgid "%(room_name)s has been quiet for %(inactivity_days)d days."
 msgstr "%(room_name)s war seit %(inactivity_days)d Tagen inaktiv."
 
-msgid "If everyone already settled up, please mark the debts as paid and close the room so it stops lingering."
-msgstr "Wenn alle bereits abgerechnet haben, markiere die Schulden bitte als bezahlt und schließe den Raum, damit er nicht weiter offen bleibt."
+#: apps/mail/services/room_closure_reminder_mail_service.py:36
+msgid ""
+"If everyone already settled up, please mark the debts as paid and close the "
+"room so it stops lingering."
+msgstr ""
+"Wenn alle bereits abgerechnet haben, markiere die Schulden bitte als bezahlt "
+"und schließe den Raum, damit er nicht weiter offen bleibt."
 
-msgid "If you still need the room, feel free to ignore this reminder and keep it open."
-msgstr "Wenn du den Raum noch brauchst, ignoriere diese Erinnerung und lasse ihn geöffnet."
+#: apps/mail/services/room_closure_reminder_mail_service.py:40
+msgid ""
+"If you still need the room, feel free to ignore this reminder and keep it "
+"open."
+msgstr ""
+"Wenn du den Raum noch brauchst, ignoriere diese Erinnerung und lasse ihn "
+"geöffnet."
 
+#: apps/mail/services/room_closure_reminder_mail_service.py:46
 #, python-format
 msgid "Room cleanup reminder: %(room_name)s"
 msgstr "Erinnerung zur Raumbereinigung: %(room_name)s"
 
-msgid "This reminder is generated automatically when open rooms stay inactive. We're happy to help."
-msgstr "Diese Erinnerung wird automatisch erzeugt, wenn offene Räume inaktiv bleiben. Wir helfen gern."
+#: apps/mail/services/room_closure_reminder_mail_service.py:47
+msgid ""
+"This reminder is generated automatically when open rooms stay inactive. "
+"We're happy to help."
+msgstr ""
+"Diese Erinnerung wird automatisch erzeugt, wenn offene Räume inaktiv "
+"bleiben. Wir helfen gern."
 
+#: apps/mail/services/room_closure_reminder_mail_service.py:48
 msgid "Give us a shout if the room history looks off."
 msgstr "Melde dich, wenn die Raumhistorie nicht stimmt."
 
+#: apps/mail/services/room_closure_reminder_mail_service.py:60
 msgid "Review room status"
 msgstr "Raumstatus prüfen"
 
+#: apps/mail/services/user_added_to_room_mail_service.py:17
 #, python-format
 msgid "Welcome to %(room_name)s"
 msgstr "Willkommen bei %(room_name)s"
 
+#: apps/mail/services/user_added_to_room_mail_service.py:22
 #, python-format
 msgid "You have been invited to %(room_name)s to join your friends"
-msgstr "Du wurdest eingeladen, dich deinen Freunden in %(room_name)s anzuschließen"
+msgstr ""
+"Du wurdest eingeladen, dich deinen Freunden in %(room_name)s anzuschließen"
 
+#: apps/mail/services/user_added_to_room_mail_service.py:24
 msgid "Click the button below to view the room!"
 msgstr "Klicke auf den Button unten, um den Raum zu sehen!"
 
+#: apps/mail/services/user_added_to_room_mail_service.py:33
 msgid "See the room"
 msgstr "Raum ansehen"
 
+#: apps/news/handlers/events/create_news_on_room_created.py:13
 #, python-brace-format
 msgid "{creator} created \"{room_name}\""
 msgstr "{creator} hat \"{room_name}\" erstellt"
 
+#: apps/news/handlers/events/create_news_on_transaction_create.py:13
 #, python-brace-format
 msgid "{payer} paid {amount}{currency} in \"{room}\""
 msgstr "{payer} hat {amount}{currency} in \"{room}\" bezahlt"
 
+#: apps/news/handlers/events/create_news_on_transaction_delete.py:12
 #, python-brace-format
-msgid "{actor} deleted the transaction \"{description}\" ({amount}{currency}) in \"{room}\""
-msgstr "{actor} hat die Transaktion \"{description}\" ({amount}{currency}) in \"{room}\" gelöscht"
+msgid ""
+"{actor} deleted the transaction \"{description}\" ({amount}{currency}) in "
+"\"{room}\""
+msgstr ""
+"{actor} hat die Transaktion \"{description}\" ({amount}{currency}) in "
+"\"{room}\" gelöscht"
 
+#: apps/news/handlers/events/create_news_on_transaction_delete.py:21
 #, python-brace-format
 msgid "{icon} {initials}: Transaction deleted"
 msgstr "{icon} {initials}: Transaktion gelöscht"
 
+#: apps/news/handlers/events/create_news_on_user_connection_to_room_created.py:14
 msgid "themselves"
 msgstr "sich selbst"
 
+#: apps/news/handlers/events/create_news_on_user_connection_to_room_created.py:16
 msgid "System"
 msgstr "System"
 
+#: apps/news/handlers/events/create_news_on_user_connection_to_room_created.py:17
 #, python-brace-format
 msgid "{created_by} added {added_user} to \"{room_name}\""
 msgstr "{created_by} hat {added_user} zu \"{room_name}\" hinzugefügt"
 
+#: apps/news/models.py:12
 msgid "Room created"
 msgstr "Raum erstellt"
 
+#: apps/news/models.py:13
 msgid "Transaction created"
 msgstr "Transaktion erstellt"
 
+#: apps/news/models.py:14
 msgid "Transaction deleted"
 msgstr "Transaktion gelöscht"
 
+#: apps/news/models.py:15
 msgid "User added"
 msgstr "Nutzer:in hinzugefügt"
 
+#: apps/news/models.py:31
 msgid "News update"
 msgstr "News Update"
 
+#: apps/news/models.py:63 apps/news/models.py:64
 msgid "News"
 msgstr "Neuigkeiten"
 
+#: apps/room/models/room.py:17 apps/room/templates/room/detail.html:17
+#: apps/templates/_side_menu_room_list.html:4
+#: apps/transaction/templates/transaction/list.html:261
 msgid "Open"
 msgstr "Offen"
 
+#: apps/room/models/room.py:18 apps/room/templates/room/detail.html:15
+#: apps/room/templates/room/partials/_detail_who_are_you.html:13
+#: apps/templates/_side_menu_room_list.html:52
+#: apps/transaction/templates/transaction/list.html:259
 msgid "Closed"
 msgstr "Geschlossen"
 
+#: apps/room/models/room.py:36
+#: apps/room/templates/room/partials/_detail_who_are_you.html:76
+#: apps/transaction/templates/transaction/create.html:272
 msgid "Room"
 msgstr "Raum"
 
+#: apps/room/models/room.py:37
 msgid "Rooms"
 msgstr "Räume"
 
+#: apps/room/models/user_connection_to_room.py:20
 #, python-brace-format
 msgid "{user} belongs to {room}"
 msgstr "{user} gehört zu {room}"
 
+#: apps/room/templates/room/create.html:15
+#: apps/room/templates/room/create.html:22
 msgid "Back to dashboard"
 msgstr "Zurück zum Dashboard"
 
+#: apps/room/templates/room/create.html:24
 msgid "Create Room"
 msgstr "Raum erstellen"
 
+#: apps/room/templates/room/create.html:61
+#: apps/templates/_side_menu_room_list.html:48
 msgid "Create"
 msgstr "Erstellen"
 
+#: apps/room/templates/room/create.html:71
 msgid "Suggested guests"
 msgstr "Vorgeschlagene Gäste"
 
+#: apps/room/templates/room/create.html:72
 msgid "Invite frequent collaborators"
 msgstr "Lade häufige Mitwirkende ein"
 
-msgid "Add past roommates with one tap. Mark your go-to teammates as friends to pin them to the top."
-msgstr "Füge frühere Mitbewohner mit einem Tippen hinzu. Markiere deine bevorzugten Teammitglieder als Freunde, um sie oben anzupinnen."
+#: apps/room/templates/room/create.html:74
+msgid ""
+"Add past roommates with one tap. Mark your go-to teammates as friends to pin "
+"them to the top."
+msgstr ""
+"Füge frühere Mitbewohner mit einem Tippen hinzu. Markiere deine bevorzugten "
+"Teammitglieder als Freunde, um sie oben anzupinnen."
 
+#: apps/room/templates/room/detail.html:9
 msgid "Room overview"
 msgstr "Raumübersicht"
 
+#: apps/room/templates/room/detail.html:11
 msgid "No description added yet."
 msgstr "Noch keine Beschreibung hinzugefügt."
 
+#: apps/room/templates/room/detail.html:20
+#: apps/room/templates/room/detail.html:39
 msgid "Preferred currency"
 msgstr "Bevorzugte Währung"
 
+#: apps/room/templates/room/detail.html:31
 msgid "Edit room"
 msgstr "Raum bearbeiten"
 
+#: apps/room/templates/room/detail.html:41
 msgid "Used as the default for new transactions."
 msgstr "Wird als Standard für neue Transaktionen verwendet."
 
+#: apps/room/templates/room/detail.html:46
 msgid "Members"
 msgstr "Mitglieder"
 
+#: apps/room/templates/room/detail.html:48
 msgid "Roommates and guests currently connected."
 msgstr "Derzeit verbundene Mitbewohner und Gäste."
 
+#: apps/room/templates/room/detail.html:53
 msgid "Closing readiness"
 msgstr "Schließbereitschaft"
 
+#: apps/room/templates/room/detail.html:55
 msgid "Ready to close"
 msgstr "Bereit zum Schließen"
 
+#: apps/room/templates/room/detail.html:56
 msgid "No unsettled debts remain."
 msgstr "Es bleiben keine offenen Schulden."
 
+#: apps/room/templates/room/detail.html:58
 msgid "Outstanding balances"
 msgstr "Ausstehende Salden"
 
+#: apps/room/templates/room/detail.html:59
 msgid "Settle open debts before closing."
 msgstr "Begleiche offene Schulden vor dem Schließen."
 
+#: apps/room/templates/room/detail.html:66
 msgid "Keep logging expenses and invite more people whenever you need to."
 msgstr "Erfasse weiterhin Ausgaben und lade bei Bedarf weitere Menschen ein."
 
-msgid "This room is locked for editing. Reopen it from the edit screen if you need to make changes."
-msgstr "Dieser Raum ist zur Bearbeitung gesperrt. Öffne ihn auf dem Bearbeitungsbildschirm, wenn du Änderungen brauchst."
+#: apps/room/templates/room/detail.html:68
+msgid ""
+"This room is locked for editing. Reopen it from the edit screen if you need "
+"to make changes."
+msgstr ""
+"Dieser Raum ist zur Bearbeitung gesperrt. Öffne ihn auf dem "
+"Bearbeitungsbildschirm, wenn du Änderungen brauchst."
 
+#: apps/room/templates/room/edit.html:5
 msgid "Back to room"
 msgstr "Zurück zum Raum"
 
+#: apps/room/templates/room/edit.html:6
 msgid "Save room details"
 msgstr "Raumdetails speichern"
 
+#: apps/room/templates/room/edit.html:7
+#: apps/templates/shared_partials/toast.html:2
 msgid "Close"
 msgstr "Schließen"
 
+#: apps/room/templates/room/edit.html:22
+#: apps/transaction/templates/transaction/category_manager.html:7
 msgid "Room settings"
 msgstr "Raumeinstellungen"
 
+#: apps/room/templates/room/edit.html:24
 #, python-format
 msgid "Edit \"%(room_name)s\""
 msgstr "\"%(room_name)s\" bearbeiten"
 
+#: apps/room/templates/room/edit.html:45
 msgid "Basics"
 msgstr "Grundlagen"
 
+#: apps/room/templates/room/edit.html:46
 msgid "Name, description & currency"
 msgstr "Name, Beschreibung & Währung"
 
+#: apps/room/templates/room/edit.html:48
 msgid "Please fix the highlighted errors in the form."
 msgstr "Bitte behebe die markierten Fehler im Formular."
 
+#: apps/room/templates/room/edit.html:112
 msgid "Room status"
 msgstr "Raumstatus"
 
+#: apps/room/templates/room/edit.html:116
 msgid "All debts are settled. You can close the room."
 msgstr "Alle Schulden sind beglichen. Du kannst den Raum schließen."
 
+#: apps/room/templates/room/edit.html:119
 #, python-format
 msgid ""
 "\n"
-"                                            There is still %(debt_count)s open debt.\n"
+"                                            There is still %(debt_count)s "
+"open debt.\n"
 "                                        "
 msgid_plural ""
 "\n"
-"                                            There are still %(debt_count)s open debts.\n"
+"                                            There are still %(debt_count)s "
+"open debts.\n"
 "                                        "
 msgstr[0] ""
 "\n"
-"                                            Es gibt noch %(debt_count)s offene Schuld.\n"
+"                                            Es gibt noch %(debt_count)s "
+"offene Schuld.\n"
 "                                        "
 msgstr[1] ""
 "\n"
-"                                            Es gibt noch %(debt_count)s offene Schulden.\n"
+"                                            Es gibt noch %(debt_count)s "
+"offene Schulden.\n"
 "                                        "
 
+#: apps/room/templates/room/edit.html:127
 msgid "The room is closed and can be reopened."
 msgstr "Der Raum ist geschlossen und kann wieder geöffnet werden."
 
+#: apps/room/templates/room/edit.html:152
+#: apps/room/templates/room/edit.html:160
 msgid "Close room"
 msgstr "Raum schließen"
 
+#: apps/room/templates/room/edit.html:167
 msgid "Reopen room"
 msgstr "Raum wieder öffnen"
 
+#: apps/room/templates/room/edit.html:186
 msgid "Category manager"
 msgstr "Kategorie-Manager"
 
+#: apps/room/templates/room/edit.html:187
 msgid "Customize tracking categories"
 msgstr "Tracking-Kategorien anpassen"
 
-msgid "Add room-specific categories and control their order without touching the global defaults."
-msgstr "Füge raumspezifische Kategorien hinzu und steuere deren Reihenfolge, ohne die globalen Standardeinstellungen zu verändern."
+#: apps/room/templates/room/edit.html:189
+msgid ""
+"Add room-specific categories and control their order without touching the "
+"global defaults."
+msgstr ""
+"Füge raumspezifische Kategorien hinzu und steuere deren Reihenfolge, ohne "
+"die globalen Standardeinstellungen zu verändern."
 
+#: apps/room/templates/room/edit.html:200
 msgid "Open manager"
 msgstr "Manager öffnen"
 
+#: apps/room/templates/room/edit.html:216
 msgid "Outstanding debts"
 msgstr "Ausstehende Schulden"
 
+#: apps/room/templates/room/edit.html:217
 msgid "This room still has outstanding payments."
 msgstr "Dieser Raum hat noch ausstehende Zahlungen."
 
+#: apps/room/templates/room/edit.html:226
 #, python-format
 msgid ""
 "\n"
-"                                    There is still %(debt_count)s open debt. Closing the room anyway will mark it as settled.\n"
+"                                    There is still %(debt_count)s open debt. "
+"Closing the room anyway will mark it as settled.\n"
 "                                "
 msgid_plural ""
 "\n"
-"                                    There are still %(debt_count)s open debts. Closing the room anyway will mark them as settled.\n"
+"                                    There are still %(debt_count)s open "
+"debts. Closing the room anyway will mark them as settled.\n"
 "                                "
 msgstr[0] ""
 "\n"
-"                                    Es gibt noch %(debt_count)s offene Schuld. Wenn du den Raum trotzdem schließt, wird sie als beglichen markiert.\n"
+"                                    Es gibt noch %(debt_count)s offene "
+"Schuld. Wenn du den Raum trotzdem schließt, wird sie als beglichen "
+"markiert.\n"
 "                                "
 msgstr[1] ""
 "\n"
-"                                    Es gibt noch %(debt_count)s offene Schulden. Wenn du den Raum trotzdem schließt, werden sie als beglichen markiert.\n"
+"                                    Es gibt noch %(debt_count)s offene "
+"Schulden. Wenn du den Raum trotzdem schließt, werden sie als beglichen "
+"markiert.\n"
 "                                "
 
+#: apps/room/templates/room/edit.html:232
 msgid "Use this option only if you want to skip manual settlement."
-msgstr "Nutze diese Option nur, wenn du die manuelle Abrechnung überspringen möchtest."
+msgstr ""
+"Nutze diese Option nur, wenn du die manuelle Abrechnung überspringen "
+"möchtest."
 
+#: apps/room/templates/room/edit.html:238
 msgid "Close anyway"
 msgstr "Trotzdem schließen"
 
+#: apps/room/templates/room/partials/_detail_who_are_you.html:15
 msgid "Open to guests"
 msgstr "Für Gäste offen"
 
-msgid "Maybe register? A free account keeps your rooms, reminders, and history together."
-msgstr "Vielleicht registrieren? Ein kostenloses Konto hält deine Räume, Erinnerungen und Historie zusammen."
+#: apps/room/templates/room/partials/_detail_who_are_you.html:20
+msgid ""
+"Maybe register? A free account keeps your rooms, reminders, and history "
+"together."
+msgstr ""
+"Vielleicht registrieren? Ein kostenloses Konto hält deine Räume, "
+"Erinnerungen und Historie zusammen."
 
+#: apps/room/templates/room/partials/_detail_who_are_you.html:29
 msgid "Claim your invitation"
 msgstr "Einladung annehmen"
 
-msgid "Guests who arrive via the shared link can register or log in here to confirm their spot."
-msgstr "Gäste, die über den geteilten Link kommen, können sich hier registrieren oder anmelden, um ihren Platz zu bestätigen."
+#: apps/room/templates/room/partials/_detail_who_are_you.html:31
+msgid ""
+"Guests who arrive via the shared link can register or log in here to confirm "
+"their spot."
+msgstr ""
+"Gäste, die über den geteilten Link kommen, können sich hier registrieren "
+"oder anmelden, um ihren Platz zu bestätigen."
 
+#: apps/room/templates/room/partials/_detail_who_are_you.html:47
 msgid "Who are you?"
 msgstr "Wer bist du?"
 
-msgid "Only Guest Users of the room are shown here. If you do not see your name, that means that you either are not part of this room or that you already have an account. If you already have an account, try logging in."
-msgstr "Nur Gastnutzer:innen des Raums werden hier angezeigt. Wenn du deinen Namen nicht siehst, bist du entweder nicht Teil dieses Raums oder hast bereits ein Konto. Wenn du schon ein Konto hast, versuche dich einzuloggen."
+#: apps/room/templates/room/partials/_detail_who_are_you.html:64
+#: apps/room/templates/room/partials/_detail_who_are_you.html:69
+msgid ""
+"Only Guest Users of the room are shown here. If you do not see your name, "
+"that means that you either are not part of this room or that you already "
+"have an account. If you already have an account, try logging in."
+msgstr ""
+"Nur Gastnutzer:innen des Raums werden hier angezeigt. Wenn du deinen Namen "
+"nicht siehst, bist du entweder nicht Teil dieses Raums oder hast bereits ein "
+"Konto. Wenn du schon ein Konto hast, versuche dich einzuloggen."
 
+#: apps/room/templates/room/partials/_detail_who_are_you.html:66
 msgid "Not seeing your name?"
 msgstr "Siehst du deinen Namen nicht?"
 
+#: apps/room/templates/room/partials/_detail_who_are_you.html:85
 msgid "That's me!"
 msgstr "Das bin ich!"
 
-msgid "No guests have been invited yet. Create an account to add yourself to the room."
-msgstr "Es wurden noch keine Gäste eingeladen. Erstelle ein Konto, um dich selbst zum Raum hinzuzufügen."
+#: apps/room/templates/room/partials/_detail_who_are_you.html:90
+msgid ""
+"No guests have been invited yet. Create an account to add yourself to the "
+"room."
+msgstr ""
+"Es wurden noch keine Gäste eingeladen. Erstelle ein Konto, um dich selbst "
+"zum Raum hinzuzufügen."
 
+#: apps/templates/_side_menu.html:2
 msgid "Toggle navigation"
 msgstr "Navigation umschalten"
 
+#: apps/templates/_side_menu.html:3
 msgid "Copy the rooms URL to your clipboard to send it to your friends"
-msgstr "Kopiere die Raum-URL in die Zwischenablage, um sie deinen Freunden zu schicken"
+msgstr ""
+"Kopiere die Raum-URL in die Zwischenablage, um sie deinen Freunden zu "
+"schicken"
 
+#: apps/templates/_side_menu.html:60
 msgid "Menu"
 msgstr "Menü"
 
+#: apps/templates/_side_menu.html:98
 msgid "Profile"
 msgstr "Profil"
 
+#: apps/templates/_side_menu.html:105
 msgid "Log in to access rooms"
 msgstr "Melde dich an, um Räume zu nutzen"
 
+#: apps/templates/_side_menu.html:107
 msgid "Manage rooms and transactions"
 msgstr "Räume und Transaktionen verwalten"
 
+#: apps/templates/_side_menu.html:124
 msgid "View profile"
 msgstr "Profil ansehen"
 
+#: apps/templates/_side_menu.html:142
 msgid "Home"
 msgstr "Startseite"
 
+#: apps/templates/_side_menu.html:143
 msgid "Back to home"
 msgstr "Zur Startseite"
 
+#: apps/templates/_side_menu.html:145
 msgid "Start"
 msgstr "Start"
 
+#: apps/templates/_side_menu.html:156
 msgid "Log out"
 msgstr "Abmelden"
 
+#: apps/templates/_side_menu_room_list.html:32
 msgid "New"
 msgstr "Neu"
 
+#: apps/templates/_side_menu_room_list.html:45
 msgid "New room"
 msgstr "Neuer Raum"
 
+#: apps/templates/_side_menu_room_list.html:46
 msgid "Start a new group with friends"
 msgstr "Starte eine neue Gruppe mit Freunden"
 
+#: apps/templates/_side_menu_room_list.html:81
 msgid "Other"
 msgstr "Andere"
 
+#: apps/templates/shared_partials/loading_spinner.html:6
 msgid "Loading..."
 msgstr "Wird geladen..."
 
+#: apps/templates/shared_partials/member_form.html:118
 msgid "Back"
 msgstr "Zurück"
 
+#: apps/templates/shared_partials/member_form.html:129
 msgid "Room access"
 msgstr "Raumzugang"
 
+#: apps/templates/shared_partials/member_form.html:141
 msgid "New member"
 msgstr "Neues Mitglied"
 
+#: apps/templates/shared_partials/member_form.html:182
 msgid "We'll notify members automatically."
 msgstr "Wir benachrichtigen die Mitglieder automatisch."
 
+#: apps/templates/shared_partials/member_form.html:192
 msgid "Submit"
 msgstr "Absenden"
 
+#: apps/templates/shared_partials/member_form.html:198
 msgid "This room is closed, so new members cannot be added."
-msgstr "Dieser Raum ist geschlossen, daher können keine neuen Mitglieder hinzugefügt werden."
+msgstr ""
+"Dieser Raum ist geschlossen, daher können keine neuen Mitglieder hinzugefügt "
+"werden."
 
+#: apps/templates/shared_partials/news_batch.html:6
 msgid "No updates yet."
 msgstr "Noch keine Updates."
 
+#: apps/templates/shared_partials/news_batch.html:36
 msgid "You are all caught up."
 msgstr "Du bist auf dem Laufenden."
 
+#: apps/templates/shared_partials/news_card.html:4
 msgid "Open related update"
 msgstr "Verwandtes Update öffnen"
 
+#: apps/templates/shared_partials/news_card.html:15
+#: apps/templates/shared_partials/news_card.html:34
 msgid "Update"
 msgstr "Aktualisierung"
 
+#: apps/templates/shared_partials/news_card.html:19
+#: apps/templates/shared_partials/news_card.html:38
 #, python-format
 msgid "%(timesince)s ago"
 msgstr "vor %(timesince)s"
 
+#: apps/templates/shared_partials/toast.html:27
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
+#: apps/templates/shared_partials/user_card.html:3
 msgid "Remove from room"
 msgstr "Aus dem Raum entfernen"
 
+#: apps/templates/shared_partials/user_card.html:30
 msgid "Guest"
 msgstr "Gast"
 
+#: apps/templates/shared_partials/user_card.html:32
 msgid "Member"
 msgstr "Mitglied"
 
+#: apps/templates/shared_partials/user_card.html:37
 msgid "Seen room"
 msgstr "Raum gesehen"
 
+#: apps/templates/shared_partials/user_card.html:39
 msgid "Not seen yet"
 msgstr "Noch nicht gesehen"
 
-msgid "Are you sure you want to remove yourself from this room? You will not be able to see this room afterwards anymore!"
-msgstr "Bist du sicher, dass du dich aus diesem Raum entfernen möchtest? Danach kannst du ihn nicht mehr sehen!"
+#: apps/templates/shared_partials/user_card.html:45
+msgid ""
+"Are you sure you want to remove yourself from this room? You will not be "
+"able to see this room afterwards anymore!"
+msgstr ""
+"Bist du sicher, dass du dich aus diesem Raum entfernen möchtest? Danach "
+"kannst du ihn nicht mehr sehen!"
 
+#: apps/templates/shared_partials/user_card.html:47
 msgid "Are you sure you wish to remove this user from this room?"
-msgstr "Bist du sicher, dass du diesen Nutzer aus diesem Raum entfernen möchtest?"
+msgstr ""
+"Bist du sicher, dass du diesen Nutzer aus diesem Raum entfernen möchtest?"
 
+#: apps/templates/shared_partials/user_card.html:64
 msgid "Guest access with limited features"
 msgstr "Gastzugang mit eingeschränkten Funktionen"
 
+#: apps/templates/shared_partials/user_card.html:66
 msgid "Registered roommate"
 msgstr "Registrierter Mitbewohner"
 
+#: apps/templates/shared_partials/user_card.html:82
 msgid "Joined as a full member of this room."
 msgstr "Als volles Mitglied dieses Raums beigetreten."
 
+#: apps/transaction/forms/room_category_forms/room_category_create_form.py:14
 msgid "Enter a color in #RRGGBB format."
 msgstr "Gib eine Farbe im Format #RRGGBB ein."
 
+#: apps/transaction/forms/room_category_forms/validators.py:9
+#: apps/transaction/forms/room_category_forms/validators.py:13
+#: apps/transaction/forms/room_category_forms/validators.py:19
 msgid "Enter a single emoji character."
 msgstr "Gib ein einzelnes Emoji-Zeichen ein."
 
+#: apps/transaction/models/child_transaction.py:22
 #, python-brace-format
 msgid "{paid_by} paid {value}{currency} for {paid_for}"
 msgstr "{paid_by} hat {value}{currency} für {paid_for} bezahlt"
 
+#: apps/transaction/templates/transaction/category_breakdown.html:30
 msgid "Back to transactions"
 msgstr "Zurück zu den Transaktionen"
 
+#: apps/transaction/templates/transaction/category_breakdown.html:33
 msgid "Category breakdown"
 msgstr "Kategorienübersicht"
 
+#: apps/transaction/templates/transaction/category_breakdown.html:34
 msgid "All recorded spend"
 msgstr "Alle erfassten Ausgaben"
 
+#: apps/transaction/templates/transaction/category_breakdown.html:36
 #, python-format
 msgid "Showing %(period)s."
 msgstr "Zeigt %(period)s."
 
+#: apps/transaction/templates/transaction/category_breakdown.html:48
 msgid "Currency breakdown"
 msgstr "Währungsaufteilung"
 
+#: apps/transaction/templates/transaction/category_breakdown.html:56
+#: apps/transaction/templates/transaction/category_breakdown.html:75
 #, python-format
 msgid ""
 "\n"
@@ -1127,34 +1675,50 @@ msgstr[1] ""
 "                                            %(category_count)s Kategorien\n"
 "                                        "
 
+#: apps/transaction/templates/transaction/category_breakdown.html:73
 msgid "Legend"
 msgstr "Legende"
 
+#: apps/transaction/templates/transaction/category_breakdown.html:103
 msgid "No tracked expenses yet. Add a transaction to populate the breakdown."
-msgstr "Noch keine erfassten Ausgaben. Füge eine Transaktion hinzu, um die Aufschlüsselung zu füllen."
+msgstr ""
+"Noch keine erfassten Ausgaben. Füge eine Transaktion hinzu, um die "
+"Aufschlüsselung zu füllen."
 
+#: apps/transaction/templates/transaction/category_breakdown.html:118
 msgid "Add expenses to unlock the breakdown."
 msgstr "Füge Ausgaben hinzu, um die Aufschlüsselung freizuschalten."
 
+#: apps/transaction/templates/transaction/category_manager.html:9
 #, python-format
 msgid "Manage categories for \"%(room_name)s\""
 msgstr "Kategorien für „%(room_name)s“ verwalten"
 
+#: apps/transaction/templates/transaction/category_manager.html:14
 msgid "Add or reorder categories that match how your group tracks spending."
-msgstr "Füge Kategorien hinzu oder ordne sie neu, die der Art und Weise entsprechen, wie deine Gruppe Ausgaben erfasst."
+msgstr ""
+"Füge Kategorien hinzu oder ordne sie neu, die der Art und Weise entsprechen, "
+"wie deine Gruppe Ausgaben erfasst."
 
+#: apps/transaction/templates/transaction/child_transaction_create.html:20
+#: apps/transaction/templates/transaction/edit.html:246
 msgid "For"
 msgstr "Für"
 
+#: apps/transaction/templates/transaction/child_transaction_create.html:29
 msgid "Remove this participant?"
 msgstr "Diese:n Teilnehmer:in entfernen?"
 
+#: apps/transaction/templates/transaction/child_transaction_create.html:37
+#: apps/transaction/templates/transaction/edit.html:276
 msgid "Child Transaction ID"
 msgstr "ID der Untertransaktion"
 
+#: apps/transaction/templates/transaction/create.html:8
 msgid "New transaction"
 msgstr "Neue Transaktion"
 
+#: apps/transaction/templates/transaction/create.html:10
 #, python-format
 msgid ""
 "\n"
@@ -1165,6 +1729,7 @@ msgstr ""
 "                        Eine Transaktion für \"%(room_name)s\" hinzufügen\n"
 "                    "
 
+#: apps/transaction/templates/transaction/create.html:18
 #, python-format
 msgid ""
 "\n"
@@ -1183,6 +1748,7 @@ msgstr[1] ""
 "                        %(member_count)s Mitglieder\n"
 "                    "
 
+#: apps/transaction/templates/transaction/create.html:26
 #, python-format
 msgid ""
 "\n"
@@ -1193,139 +1759,206 @@ msgstr ""
 "                        %(currency_sign)s bevorzugt\n"
 "                    "
 
+#: apps/transaction/templates/transaction/create.html:44
 msgid "Unable to add transaction"
 msgstr "Transaktion konnte nicht hinzugefügt werden"
 
+#: apps/transaction/templates/transaction/create.html:53
 msgid "Required details"
 msgstr "Erforderliche Angaben"
 
+#: apps/transaction/templates/transaction/create.html:56
 msgid "What was this?"
 msgstr "Was war das?"
 
+#: apps/transaction/templates/transaction/create.html:65
 msgid "e.g., Grocery run"
 msgstr "e.g., Einkaufen"
 
+#: apps/transaction/templates/transaction/create.html:72
+#: apps/transaction/templates/transaction/edit.html:155
 msgid "Maximum 50 characters."
 msgstr "Maximal 50 Zeichen."
 
+#: apps/transaction/templates/transaction/create.html:75
 msgid "Amount paid"
 msgstr "Bezahlter Betrag"
 
+#: apps/transaction/templates/transaction/create.html:92
 msgid "Total paid in the selected currency."
 msgstr "In der gewählten Währung insgesamt bezahlt."
 
+#: apps/transaction/templates/transaction/create.html:97
 msgid "Who paid?"
 msgstr "Wer hat bezahlt?"
 
+#: apps/transaction/templates/transaction/create.html:118
 msgid "Person covering this expense."
 msgstr "Die Person, die diese Ausgabe getragen hat."
 
+#: apps/transaction/templates/transaction/create.html:121
+#: apps/transaction/templates/transaction/detail.html:85
+#: apps/transaction/templates/transaction/edit.html:205
 msgid "Split between"
 msgstr "Aufgeteilt auf"
 
+#: apps/transaction/templates/transaction/create.html:137
 msgid "Hold Cmd/Ctrl to adjust beneficiaries."
 msgstr "Halte Cmd/Ctrl gedrückt, um die Begünstigten anzupassen."
 
+#: apps/transaction/templates/transaction/create.html:144
 msgid "Optional"
 msgstr "Optional"
 
+#: apps/transaction/templates/transaction/create.html:145
 msgid "More details"
 msgstr "Weitere Details"
 
+#: apps/transaction/templates/transaction/create.html:153
 msgid "Show fields"
 msgstr "Felder anzeigen"
 
+#: apps/transaction/templates/transaction/create.html:160
+#: apps/transaction/templates/transaction/edit.html:137
+#: apps/transaction/views/transaction_export_view.py:17
 msgid "Paid at"
 msgstr "Bezahlt am"
 
+#: apps/transaction/templates/transaction/create.html:173
 msgid "Use if the expense occurred earlier."
 msgstr "Verwenden, wenn die Ausgabe früher stattfand."
 
+#: apps/transaction/templates/transaction/create.html:197
 msgid "Defaults to the room preference."
 msgstr "Standardmäßig wird die Raumpräferenz verwendet."
 
+#: apps/transaction/templates/transaction/create.html:200
+#: apps/transaction/templates/transaction/edit.html:160
+#: apps/transaction/views/transaction_export_view.py:17
 msgid "Category"
 msgstr "Kategorie"
 
+#: apps/transaction/templates/transaction/create.html:215
 msgid "Tag this expense for dashboards and charts."
 msgstr "Markiere diese Ausgabe für Dashboards und Diagramme."
 
+#: apps/transaction/templates/transaction/create.html:219
+#: apps/transaction/templates/transaction/detail.html:76
+#: apps/transaction/templates/transaction/edit.html:309
+#: apps/transaction/templates/transaction/edit.html:311
 msgid "Notes"
 msgstr "Notizen"
 
+#: apps/transaction/templates/transaction/create.html:227
 msgid "Add split details, receipts, or reminders"
 msgstr "Füge Aufteilungsdetails, Belege oder Erinnerungen hinzu"
 
+#: apps/transaction/templates/transaction/create.html:230
 msgid "Up to 5000 characters."
 msgstr "Bis zu 5000 Zeichen."
 
+#: apps/transaction/templates/transaction/create.html:233
+#: apps/transaction/templates/transaction/edit.html:178
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:6
 msgid "Receipts"
 msgstr "Belege"
 
+#: apps/transaction/templates/transaction/create.html:245
 msgid "Upload receipts as PDF or image (max 5 MB each)."
 msgstr "Lade Belege als PDF oder Bild hoch (maximal 5 MB pro Datei)."
 
+#: apps/transaction/templates/transaction/create.html:253
+#: apps/transaction/templates/transaction/list.html:179
+#: apps/transaction/templates/transaction/list.html:180
 msgid "Add transaction"
 msgstr "Transaktion hinzufügen"
 
+#: apps/transaction/templates/transaction/create.html:263
 msgid "Room Slug"
 msgstr "Raum-Slug"
 
+#: apps/transaction/templates/transaction/create.html:281
 msgid "Groceries"
 msgstr "Lebensmittel"
 
+#: apps/transaction/templates/transaction/create.html:282
 msgid "Utilities"
 msgstr "Nebenkosten"
 
+#: apps/transaction/templates/transaction/create.html:283
 msgid "Dinner"
 msgstr "Abendessen"
 
+#: apps/transaction/templates/transaction/create.html:284
 msgid "Ride share"
 msgstr "Fahrgemeinschaft"
 
+#: apps/transaction/templates/transaction/create.html:285
 msgid "House supplies"
 msgstr "Haushaltsbedarf"
 
+#: apps/transaction/templates/transaction/detail.html:17
+#: apps/transaction/templates/transaction/edit.html:59
 msgid "Back to list"
 msgstr "Zurück zur Liste"
 
+#: apps/transaction/templates/transaction/detail.html:20
 msgid "Expense"
 msgstr "Ausgabe"
 
+#: apps/transaction/templates/transaction/detail.html:25
 msgid "paid"
 msgstr "bezahlt"
 
+#: apps/transaction/templates/transaction/detail.html:31
 msgid "Edit transaction"
 msgstr "Transaktion bearbeiten"
 
+#: apps/transaction/templates/transaction/detail.html:35
 msgid "Edit expense"
 msgstr "Ausgabe bearbeiten"
 
+#: apps/transaction/templates/transaction/detail.html:40
 msgid "This room is closed, so the breakdown is read-only."
 msgstr "Dieser Raum ist geschlossen, daher ist die Aufschlüsselung read-only."
 
+#: apps/transaction/templates/transaction/detail.html:47
 msgid "Total amount"
 msgstr "Gesamtbetrag"
 
+#: apps/transaction/templates/transaction/detail.html:54
+#: apps/transaction/templates/transaction/edit.html:91
+#: apps/transaction/views/transaction_export_view.py:17
 msgid "Paid by"
 msgstr "Bezahlt von"
 
+#: apps/transaction/templates/transaction/detail.html:58
 msgid "on"
 msgstr "am"
 
+#: apps/transaction/templates/transaction/detail.html:61
 #, python-format
 msgid "Recorded at %(recorded_time)s"
 msgstr "Erfasst um %(recorded_time)s"
 
+#: apps/transaction/templates/transaction/detail.html:66
+#: apps/transaction/templates/transaction/edit.html:147
+#: apps/transaction/templates/transaction/edit.html:149
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:23
+#: apps/transaction/views/transaction_export_view.py:17
 msgid "Description"
 msgstr "Beschreibung"
 
+#: apps/transaction/templates/transaction/detail.html:69
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:24
 msgid "No description"
 msgstr "Keine Beschreibung"
 
+#: apps/transaction/templates/transaction/detail.html:86
 msgid "Tap a row to edit the breakdown."
 msgstr "Tippe auf eine Zeile, um die Aufschlüsselung zu bearbeiten."
 
+#: apps/transaction/templates/transaction/detail.html:89
 #, python-format
 msgid ""
 "\n"
@@ -1344,6 +1977,7 @@ msgstr[1] ""
 "                        %(member_count)s Personen\n"
 "                    "
 
+#: apps/transaction/templates/transaction/detail.html:107
 #, python-format
 msgid ""
 "\n"
@@ -1351,52 +1985,73 @@ msgid ""
 "                                "
 msgstr ""
 "\n"
-"                                    Schuldet %(owed_value)s%(owed_currency)s\n"
+"                                    Schuldet "
+"%(owed_value)s%(owed_currency)s\n"
 "                                "
 
+#: apps/transaction/templates/transaction/detail.html:119
 msgid "No split data available for this transaction yet."
 msgstr "Für diese Transaktion liegen noch keine Splits-Daten vor."
 
+#: apps/transaction/templates/transaction/edit.html:62
 msgid "Editing expense"
 msgstr "Ausgabe bearbeiten"
 
+#: apps/transaction/templates/transaction/edit.html:63
 msgid "Adjust who paid and how it is split."
 msgstr "Leg fest, wer bezahlt hat und wie geteilt wird."
 
+#: apps/transaction/templates/transaction/edit.html:70
+#: apps/transaction/templates/transaction/edit.html:263
 msgid "Are you sure you wish to delete this transaction?"
 msgstr "Bist du sicher, dass du diese Transaktion löschen möchtest?"
 
+#: apps/transaction/templates/transaction/edit.html:77
 msgid "Delete"
 msgstr "Löschen"
 
+#: apps/transaction/templates/transaction/edit.html:100
 msgid "Total"
 msgstr "Gesamt"
 
+#: apps/transaction/templates/transaction/edit.html:122
 #, python-format
 msgid ""
 "\n"
-"                                    Current split: %(split_total)s%(split_currency)s\n"
+"                                    Current split: "
+"%(split_total)s%(split_currency)s\n"
 "                                "
 msgstr ""
 "\n"
-"                                    Aktuelle Aufteilung: %(split_total)s%(split_currency)s\n"
+"                                    Aktuelle Aufteilung: "
+"%(split_total)s%(split_currency)s\n"
 "                                "
 
+#: apps/transaction/templates/transaction/edit.html:169
 msgid "Use categories to group similar spend."
 msgstr "Nutze Kategorien, um ähnliche Ausgaben zu bündeln."
 
+#: apps/transaction/templates/transaction/edit.html:180
 msgid "Receipts stay on the detail page, so upload PDFs there instead of here."
 msgstr "Belege bleiben auf der Detailseite, lade PDFs dort statt hier hoch."
 
-msgid "You can continue editing this transaction; switch to the detail view if you need to manage uploads."
-msgstr "Du kannst diese Transaktion weiter bearbeiten; wechsle zur Detailansicht, wenn du Uploads verwalten möchtest."
+#: apps/transaction/templates/transaction/edit.html:185
+msgid ""
+"You can continue editing this transaction; switch to the detail view if you "
+"need to manage uploads."
+msgstr ""
+"Du kannst diese Transaktion weiter bearbeiten; wechsle zur Detailansicht, "
+"wenn du Uploads verwalten möchtest."
 
+#: apps/transaction/templates/transaction/edit.html:196
 msgid "Open detail view"
 msgstr "Detailansicht öffnen"
 
+#: apps/transaction/templates/transaction/edit.html:206
 msgid "Update each share or remove it entirely."
 msgstr "Aktualisiere jeden Anteil oder entferne ihn vollständig."
 
+#: apps/transaction/templates/transaction/edit.html:210
 #, python-format
 msgid ""
 "\n"
@@ -1415,81 +2070,113 @@ msgstr[1] ""
 "                                    %(participant_count)s Personen\n"
 "                                "
 
-msgid "⚠️ Total edits lock individual share inputs; the backend will rebalance splits automatically."
-msgstr "⚠️ Gesamte Änderungen sperren einzelne Anteile; das Backend gleicht die Splits automatisch aus."
+#: apps/transaction/templates/transaction/edit.html:219
+msgid ""
+"⚠️ Total edits lock individual share inputs; the backend will rebalance "
+"splits automatically."
+msgstr ""
+"⚠️ Gesamte Änderungen sperren einzelne Anteile; das Backend gleicht die "
+"Splits automatisch aus."
 
+#: apps/transaction/templates/transaction/edit.html:290
 msgid "No split entries yet."
 msgstr "Noch keine Splits erfasst."
 
+#: apps/transaction/templates/transaction/edit.html:302
 msgid "Add participant"
 msgstr "Teilnehmer hinzufügen"
 
+#: apps/transaction/templates/transaction/edit.html:317
 msgid "Add extra notes here"
 msgstr "Hier zusätzliche Notizen hinzufügen"
 
+#: apps/transaction/templates/transaction/list.html:169
 msgid "Room transactions"
 msgstr "Raumtransaktionen"
 
+#: apps/transaction/templates/transaction/list.html:171
 msgid "Click a row to explore the full breakdown."
 msgstr "Klicke eine Zeile, um die vollständige Aufschlüsselung zu sehen."
 
+#: apps/transaction/templates/transaction/list.html:173
 msgid "Record your first expense to see the running history here."
 msgstr "Erfasse deine erste Ausgabe, um den Verlauf hier anzuzeigen."
 
+#: apps/transaction/templates/transaction/list.html:192
 msgid "This room is closed, so transactions are read-only."
 msgstr "Dieser Raum ist geschlossen, daher sind Transaktionen nur lesbar."
 
+#: apps/transaction/templates/transaction/list.html:197
 msgid "Search"
 msgstr "Suche"
 
+#: apps/transaction/templates/transaction/list.html:203
 msgid "Filter by payer or description"
 msgstr "Nach Zahler:in oder Beschreibung filtern"
 
+#: apps/transaction/templates/transaction/list.html:217
 msgid "Details"
 msgstr "Details"
 
+#: apps/transaction/templates/transaction/list.html:218
 msgid "Actions"
 msgstr "Aktionen"
 
+#: apps/transaction/templates/transaction/list.html:245
 msgid "Nothing to show yet"
 msgstr "Noch nichts zu zeigen"
 
+#: apps/transaction/templates/transaction/list.html:246
 msgid "Start by logging an expense to build your history."
 msgstr "Erfasse zuerst eine Ausgabe, um deinen Verlauf aufzubauen."
 
+#: apps/transaction/templates/transaction/list.html:254
 msgid "Room snapshot"
 msgstr "Raumzusammenfassung"
 
+#: apps/transaction/templates/transaction/list.html:266
 msgid "Transactions logged"
 msgstr "Erfasste Transaktionen"
 
+#: apps/transaction/templates/transaction/list.html:272
 msgid "Last transaction"
 msgstr "Letzte Transaktion"
 
+#: apps/transaction/templates/transaction/list.html:277
 msgid "Invite your roommates to start sharing expenses."
 msgstr "Lade deine Mitbewohner ein, Ausgaben gemeinsam zu teilen."
 
+#: apps/transaction/templates/transaction/list.html:283
 msgid "Tips"
 msgstr "Tipps"
 
+#: apps/transaction/templates/transaction/list.html:285
 msgid "Use the search field to filter by payer or description."
 msgstr "Nutze das Suchfeld, um nach Zahler:in oder Beschreibung zu filtern."
 
+#: apps/transaction/templates/transaction/list.html:286
 msgid "Tap a row or the eye icon to review the split details."
-msgstr "Tippe eine Zeile oder das Augensymbol an, um die Split-Details anzusehen."
+msgstr ""
+"Tippe eine Zeile oder das Augensymbol an, um die Split-Details anzusehen."
 
+#: apps/transaction/templates/transaction/list.html:287
 msgid "The floating '+' button lets you capture a new transaction."
-msgstr "Der schwebende '+'-Button ermöglicht dir, eine neue Transaktion zu erfassen."
+msgstr ""
+"Der schwebende '+'-Button ermöglicht dir, eine neue Transaktion zu erfassen."
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:79
 msgid "Back to debts"
 msgstr "Zurück zu Schulden"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:82
 msgid "Room spending overview"
 msgstr "Übersicht der Raumausgaben"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:83
 msgid "Who paid what"
 msgstr "Wer hat was bezahlt"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:92
 #, python-format
 msgid ""
 "\n"
@@ -1497,54 +2184,79 @@ msgid ""
 "                                "
 msgstr ""
 "\n"
-"                                    Insgesamt ausgegeben (%(currency_sign)s)\n"
+"                                    Insgesamt ausgegeben "
+"(%(currency_sign)s)\n"
 "                                "
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:103
 msgid "No spending yet"
 msgstr "Noch keine Ausgaben"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:104
 msgid "Add expenses to populate this dashboard."
 msgstr "Füge Ausgaben hinzu, um dieses Dashboard zu füllen."
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:115
 msgid "Money spent by members"
 msgstr "Von Mitgliedern ausgegebenes Geld"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:116
 msgid "Who covered the bills"
 msgstr "Wer hat die Rechnungen bezahlt"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:148
 msgid "No payments recorded yet"
 msgstr "Noch keine Zahlungen erfasst"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:149
 msgid "As soon as someone logs an expense, their share appears here."
 msgstr "Sobald jemand eine Ausgabe erfasst, erscheint sein Anteil hier."
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:160
 msgid "Money still owed"
 msgstr "Noch geschuldetes Geld"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:161
 msgid "Who needs to settle up"
 msgstr "Wer muss noch ausgleichen"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:165
 msgid "Pending balances"
 msgstr "Ausstehende Salden"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:170
+msgid "Open debt (after optimisation)"
+msgstr "Offene Schulden (nach Optimierung)"
+
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:194
 msgid "Nothing owed right now"
 msgstr "Aktuell keine Schulden"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:195
 msgid "All participants are even for the tracked expenses."
 msgstr "Alle Teilnehmer sind für die erfassten Ausgaben ausgeglichen."
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:201
+msgid "Covered by others (gross)"
+msgstr "Von anderen übernommen (brutto)"
+
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:236
 msgid "Loading spending timeline…"
 msgstr "Verlauf wird geladen…"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:253
 msgid "Not enough data to render the chart yet."
 msgstr "Noch nicht genug Daten, um das Diagramm darzustellen."
 
+#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:8
 msgid "Spending over time"
 msgstr "Ausgaben über die Zeit"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:9
 msgid "Expense build-up"
 msgstr "Ausgabenaufbau"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:11
 #, python-format
 msgid ""
 "\n"
@@ -1555,30 +2267,40 @@ msgstr ""
 "                                Zeigt %(period)s (%(start)s – %(end)s).\n"
 "                            "
 
+#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:19
 msgid "Spending trend ranges"
 msgstr "Ausgabentrend-Intervalle"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:33
 msgid "Updating..."
 msgstr "Wird aktualisiert..."
 
+#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:46
 msgid "No data available"
 msgstr "Keine Daten verfügbar"
 
+#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:47
 msgid "Add a few expenses to unlock the timeline."
 msgstr "Füge ein paar Ausgaben hinzu, um die Timeline freizuschalten."
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:7
 msgid "Stored documents are linked to this transaction."
 msgstr "Gespeicherte Dokumente sind mit dieser Transaktion verknüpft."
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:21
 msgid "Permanently delete this receipt?"
 msgstr "Beleg dauerhaft löschen?"
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:26
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:27
 msgid "Delete receipt"
 msgstr "Beleg löschen"
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:50
 msgid "PDF receipt preview"
 msgstr "PDF-Beleg-Vorschau"
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:60
 #, python-format
 msgid ""
 "\n"
@@ -1589,72 +2311,99 @@ msgstr ""
 "                                            Hochgeladen von %(uploader)s\n"
 "                                        "
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:71
 msgid "No receipts have been attached to this transaction yet."
 msgstr "Dieser Transaktion wurden noch keine Belege beigefügt."
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:77
 msgid "Receipts cannot be uploaded after the room has been closed."
 msgstr "Belege können nach Schließen des Raums nicht mehr hochgeladen werden."
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:94
 msgid "Upload receipt"
 msgstr "Beleg hochladen"
 
+#: apps/transaction/templates/transaction/partials/_receipts_section.html:100
 msgid "PDF or PNG/JPEG/WebP/GIF (max 5 MB)."
 msgstr "PDF oder PNG/JPEG/WebP/GIF (max. 5 MB)."
 
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:7
 msgid "Create new category"
 msgstr "Neue Kategorie erstellen"
 
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:8
 msgid "Room-only categories"
 msgstr "Raumspezifische Kategorien"
 
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:34
 msgid "Emoji"
 msgstr "Emoji"
 
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:47
 msgid "Color"
 msgstr "Farbe"
 
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:62
 msgid "Order index"
 msgstr "Sortierungsindex"
 
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:81
 msgid "Set as default"
 msgstr "Als Standard festlegen"
 
+#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:87
 msgid "Add category"
 msgstr "Kategorie hinzufügen"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:7
 msgid "Available categories"
 msgstr "Verfügbare Kategorien"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:8
 msgid "Room catalog"
 msgstr "Raum Katalog"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:11
 msgid "Global defaults"
 msgstr "Globale Standards"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:13
 msgid "Customized"
 msgstr "Angepasst"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:32
 msgid "Remove"
 msgstr "Entfernen"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:40
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:98
 msgid "Default"
 msgstr "Standard"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:43
 msgid "Auto assigned"
 msgstr "Automatisch zugewiesen"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:56
 msgid "Order"
 msgstr "Sortierung"
 
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:81
 msgid "Save order for this category"
 msgstr "Reihenfolge für diese Kategorie speichern"
 
-msgid "No room-specific categories yet. Create one to override the shared baseline."
-msgstr "Noch keine raumspezifischen Kategorien vorhanden. Erstelle eine, um die gemeinsame Basislinie zu überschreiben."
+#: apps/transaction/templates/transaction/partials/_room_category_list.html:110
+msgid ""
+"No room-specific categories yet. Create one to override the shared baseline."
+msgstr ""
+"Noch keine raumspezifischen Kategorien vorhanden. Erstelle eine, um die "
+"gemeinsame Basislinie zu überschreiben."
 
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:31
 msgid "Paid on"
 msgstr "Bezahlt am"
 
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:34
 #, python-format
 msgid ""
 "\n"
@@ -1665,38 +2414,52 @@ msgstr ""
 "                                Vor %(delta)s\n"
 "                            "
 
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:40
 msgid "Payer"
 msgstr "Zahler:in"
 
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:54
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:55
 msgid "View split details"
 msgstr "Split-Details ansehen"
 
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:68
 #, python-format
 msgid "No transactions match \"%(query)s\"."
 msgstr "Keine Transaktionen entsprechen \"%(query)s\"."
 
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:70
 msgid "No transactions to show yet."
 msgstr "Noch keine Transaktionen anzuzeigen."
 
+#: apps/transaction/templates/transaction/partials/_transaction_batch.html:104
 msgid "You're all caught up."
 msgstr "Du bist auf dem Laufenden."
 
+#: apps/transaction/views/category_manager_view.py:65
 msgid "Unable to update that category. Please correct the highlighted fields."
-msgstr "Diese Kategorie kann nicht aktualisiert werden. Bitte korrigiere die markierten Felder."
+msgstr ""
+"Diese Kategorie kann nicht aktualisiert werden. Bitte korrigiere die "
+"markierten Felder."
 
+#: apps/transaction/views/category_manager_view.py:164
 msgid "Category added."
 msgstr "Kategorie hinzugefügt."
 
+#: apps/transaction/views/category_manager_view.py:167
 #, python-format
 msgid "Category \"%(category)s\" deleted."
 msgstr "Kategorie \"%(category)s\" gelöscht."
 
+#: apps/transaction/views/transaction_export_view.py:17
 msgid "Paid for"
 msgstr "Bezahlt für"
 
+#: apps/transaction/views/transaction_export_view.py:35
 msgid "transactions"
 msgstr "transaktionen"
 
+#: apps/webpush/models/web_push_information.py:24
 #, python-brace-format
 msgid "Webpush Information for {user}"
 msgstr "Webpush-Information für {user}"

--- a/apps/locale/de/LC_MESSAGES/django.po
+++ b/apps/locale/de/LC_MESSAGES/django.po
@@ -2,7 +2,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yamsa\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 10:01+0200\n"
 "PO-Revision-Date: 2025-01-01 00:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -12,399 +11,266 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/account/forms/change_password_form.py:11
 msgid "Your current password is incorrect"
 msgstr "Dein aktuelles Passwort ist falsch"
 
-#: apps/account/forms/change_password_form.py:12
 msgid "Passwords do not match"
 msgstr "Passwörter stimmen nicht überein"
 
-#: apps/account/forms/change_password_form.py:16
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: apps/account/forms/change_password_form.py:17
 msgid "Your new password"
 msgstr "Dein neues Passwort"
 
-#: apps/account/forms/change_password_form.py:18
 msgid "Confirm your new password"
 msgstr "Bestätige dein neues Passwort"
 
-#: apps/account/forms/edit_user_form.py:12
 msgid "We could not read that file. Please upload a valid image."
-msgstr ""
-"Wir konnten diese Datei nicht lesen. Bitte lade ein gültiges Bild hoch."
+msgstr "Wir konnten diese Datei nicht lesen. Bitte lade ein gültiges Bild hoch."
 
-#: apps/account/forms/edit_user_form.py:13
 msgid "The profile picture could not be reduced enough. Try a smaller file."
-msgstr ""
-"Das Profilbild konnte nicht ausreichend verkleinert werden. Versuche es mit "
-"einer kleineren Datei."
+msgstr "Das Profilbild konnte nicht ausreichend verkleinert werden. Versuche es mit einer kleineren Datei."
 
-#: apps/account/forms/edit_user_form.py:32
 msgid "Receive push notifications"
 msgstr "Push-Benachrichtigungen erhalten"
 
-#: apps/account/forms/edit_user_form.py:33
-#: apps/account/templates/account/detail.html:77
 msgid "Preferred language"
 msgstr "Bevorzugte Sprache"
 
-#: apps/account/forms/edit_user_form.py:34
 msgid "Receive payment reminder emails"
 msgstr "E-Mail-Erinnerungen an Zahlungen erhalten"
 
-#: apps/account/forms/edit_user_form.py:35
 msgid "Receive room reminder emails"
 msgstr "E-Mail-Erinnerungen zum Raum erhalten"
 
-#: apps/account/forms/guest_send_invitation_form.py:10
 #, python-brace-format
 msgid "User with email address '{email}' already exists"
 msgstr "Benutzer:in mit der E-Mail-Adresse '{email}' existiert bereits"
 
-#: apps/account/forms/register_form.py:12
 #, python-brace-format
 msgid "The email address '{email}' is already in use"
 msgstr "Die E-Mail-Adresse '{email}' wird bereits verwendet"
 
-#: apps/account/forms/user_forgot_password_form.py:10
 #, python-brace-format
 msgid "The email address '{email}' is not registered with yamsa"
 msgstr "Die E-Mail-Adresse '{email}' ist nicht bei yamsa registriert"
 
-#: apps/account/forms/user_forgot_password_form.py:13
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:21
 msgid "Email"
 msgstr "E-Mail"
 
-#: apps/account/forms/user_forgot_password_form.py:14
 msgid "Email your account is linked to"
 msgstr "E-Mail-Adresse, mit der dein Konto verknüpft ist"
 
-#: apps/account/models/user.py:71
 msgid "Staff Status"
 msgstr "Status der Mitarbeitenden"
 
-#: apps/account/models/user.py:73
 msgid "Designates whether the user can log into this admin site."
 msgstr "Legt fest, ob Benutzer:innen sich im Adminbereich anmelden kann."
 
-#: apps/account/models/user.py:88
 msgid "User"
 msgstr "Benutzer:in"
 
-#: apps/account/models/user.py:89
 msgid "Users"
 msgstr "Benutzer:innen"
 
-#: apps/account/models/user_friendship.py:12
 msgid "User friendship"
 msgstr "Benutzer:innenfreundschaft"
 
-#: apps/account/models/user_friendship.py:13
 msgid "User friendships"
 msgstr "Benutzer:innenfreundschaften"
 
-#: apps/account/models/user_friendship.py:34
 msgid "Users cannot be friends with themselves."
 msgstr "Benutzer:innen können nicht mit sich selbst befreundet sein."
 
-#: apps/account/templates/account/change_password.html:9
 msgid "Change your password:"
 msgstr "Ändere dein Passwort:"
 
-#: apps/account/templates/account/change_password.html:18
-#: apps/room/templates/room/edit.html:36
 msgid "Save"
 msgstr "Speichern"
 
-#: apps/account/templates/account/change_password.html:24
 msgid "Note:"
 msgstr "Achtung:"
 
-#: apps/account/templates/account/change_password.html:24
-msgid ""
-"After a successful password change, you will be prompted to login again."
-msgstr ""
-"Nach einer erfolgreichen Passwortänderung wirst du aufgefordert, dich erneut "
-"anzumelden."
+msgid "After a successful password change, you will be prompted to login again."
+msgstr "Nach einer erfolgreichen Passwortänderung wirst du aufgefordert, dich erneut anzumelden."
 
-#: apps/account/templates/account/create_guest.html:6
 #, python-format
 msgid "Invite a guest to \"%(room)s\""
 msgstr "Gast zu \"%(room)s\" einladen"
 
-#: apps/account/templates/account/create_guest.html:7
-#: apps/account/templates/account/create_guest.html:8
-#: apps/account/templates/account/list.html:218
-#: apps/account/templates/account/list.html:230
-#: apps/room/templates/room/partials/_detail_who_are_you.html:8
 msgid "Guest access"
 msgstr "Gastzugang"
 
-#: apps/account/templates/account/create_guest.html:9
 msgid "Perfect for roommates without accounts - give them lightweight access."
 msgstr "Perfekt für Mitbewohner ohne Konto - gib ihnen leichten Zugang."
 
-#: apps/account/templates/account/create_guest.html:10
 msgid "Guest pass"
 msgstr "Gastpass"
 
-#: apps/account/templates/account/create_guest.html:11
 msgid "Guest name"
 msgstr "Gastname"
 
-#: apps/account/templates/account/create_guest.html:12
 msgid "e.g. Alex from the kitchen"
 msgstr "z. B. Alex aus der Küche"
 
-#: apps/account/templates/account/create_guest.html:13
 msgid "Guests can later convert to full accounts without losing history."
-msgstr ""
-"Gäste können später in vollständige Konten konvertieren, ohne ihre Historie "
-"zu verlieren."
+msgstr "Gäste können später in vollständige Konten konvertieren, ohne ihre Historie zu verlieren."
 
-#: apps/account/templates/account/create_guest.html:14
 msgid "We'll drop them right into this room."
 msgstr "Wir setzen sie direkt in diesen Raum."
 
-#: apps/account/templates/account/create_guest.html:15
-#: apps/account/templates/account/list.html:192
 msgid "Add guest"
 msgstr "Gast hinzufügen"
 
-#: apps/account/templates/account/create_guest.html:16
 msgid "Back to people"
 msgstr "Zurück zur Personenliste"
 
-#: apps/account/templates/account/detail.html:11
 msgid "Guest Mode"
 msgstr "Gastmodus"
 
-#: apps/account/templates/account/detail.html:14
 #, python-format
 msgid "Hi %(user.name)s"
 msgstr "Hallo %(user.name)s"
 
-#: apps/account/templates/account/detail.html:20
-msgid ""
-"Thanks for hopping into a room as a guest. Unlock reminders, push "
-"notifications, and richer history once you create a full account."
-msgstr ""
-"Danke, dass du als Gast einem Raum beigetreten bist. Schalte Erinnerungen, "
-"Push-Benachrichtigungen und ausführlichere Historie frei, sobald du ein "
-"vollständiges Konto erstellst."
+msgid "Thanks for hopping into a room as a guest. Unlock reminders, push notifications, and richer history once you create a full account."
+msgstr "Danke, dass du als Gast einem Raum beigetreten bist. Schalte Erinnerungen, Push-Benachrichtigungen und ausführlichere Historie frei, sobald du ein vollständiges Konto erstellst."
 
-#: apps/account/templates/account/detail.html:23
-#: apps/room/templates/room/partials/_detail_who_are_you.html:35
 msgid "Create a free account"
 msgstr "Kostenloses Konto erstellen"
 
-#: apps/account/templates/account/detail.html:25
 msgid "I already have an account"
 msgstr "Ich habe bereits ein Konto"
 
-#: apps/account/templates/account/detail.html:28
 msgid "Not you?"
 msgstr "Nicht du?"
 
-#: apps/account/templates/account/detail.html:28
 msgid "Log out instead"
 msgstr "Stattdessen abmelden"
 
-#: apps/account/templates/account/detail.html:42
 msgid "Admin"
 msgstr "Administrator"
 
-#: apps/account/templates/account/detail.html:69
 msgid "Your account overview"
 msgstr "Deine Kontenübersicht"
 
-#: apps/account/templates/account/detail.html:71
 msgid "Member profile"
 msgstr "Mitgliederprofil"
 
-#: apps/account/templates/account/detail.html:78
 msgid "Not set"
 msgstr "Nicht gesetzt"
 
-#: apps/account/templates/account/detail.html:82
 msgid "Superuser"
 msgstr "Superuser"
 
-#: apps/account/templates/account/detail.html:85
 msgid "Staff"
 msgstr "Mitarbeitende"
 
-#: apps/account/templates/account/detail.html:89
 msgid "PayPal linked"
 msgstr "PayPal verknüpft"
 
-#: apps/account/templates/account/detail.html:91
 msgid "No PayPal link"
 msgstr "Kein PayPal-Link"
 
-#: apps/account/templates/account/detail.html:105
-#: apps/account/templates/account/edit.html:19
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: apps/account/templates/account/detail.html:117
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: apps/account/templates/account/detail.html:123
-#: apps/account/templates/account/forgot_password.html:41
-#: apps/account/templates/account/login.html:44
-#: apps/account/templates/account/register.html:54
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: apps/account/templates/account/detail.html:129
 msgid "PayPal.me username"
 msgstr "PayPal.me-Benutzername"
 
-#: apps/account/templates/account/detail.html:133
 msgid "No PayPal link yet"
 msgstr "Noch kein PayPal-Link"
 
-#: apps/account/templates/account/detail.html:141
 msgid "Push notifications"
 msgstr "Push-Benachrichtigungen"
 
-#: apps/account/templates/account/detail.html:144
-#: apps/account/templates/account/detail.html:167
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: apps/account/templates/account/detail.html:146
-#: apps/account/templates/account/detail.html:169
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: apps/account/templates/account/detail.html:149
 msgid "Manage this toggle from the edit screen."
 msgstr "Verwalte diesen Schalter im Bearbeitungsbildschirm."
 
-#: apps/account/templates/account/detail.html:164
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:4
 msgid "Payment reminders"
 msgstr "Zahlungserinnerungen"
 
-#: apps/account/templates/account/detail.html:172
 msgid "Toggle this in the notifications center or via the email footer."
-msgstr ""
-"Schalte dies im Benachrichtigungszentrum oder über die Fußzeile der E-Mail "
-"um."
+msgstr "Schalte dies im Benachrichtigungszentrum oder über die Fußzeile der E-Mail um."
 
-#: apps/account/templates/account/detail.html:189
-#: apps/account/templates/account/edit.html:188
 msgid "Security"
 msgstr "Sicherheit"
 
-#: apps/account/templates/account/detail.html:190
 msgid "Change your password"
 msgstr "Ändere dein Passwort"
 
-#: apps/account/templates/account/detail.html:191
 msgid "Choose a unique password to keep your rooms safe."
 msgstr "Wähle ein einzigartiges Passwort, um deine Räume zu schützen."
 
-#: apps/account/templates/account/detail.html:200
-#: apps/account/templates/account/edit.html:201
 msgid "Change password"
 msgstr "Passwort ändern"
 
-#: apps/account/templates/account/edit.html:20
 msgid "Keep your details up to date"
 msgstr "Halte deine Daten aktuell"
 
-#: apps/account/templates/account/edit.html:29
-#: apps/room/templates/room/edit.html:237
-#: apps/transaction/templates/transaction/create.html:259
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: apps/account/templates/account/edit.html:32
-#: apps/transaction/templates/transaction/edit.html:324
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: apps/account/templates/account/edit.html:42
 msgid "Profile picture preview"
 msgstr "Vorschau des Profilbilds"
 
-#: apps/account/templates/account/edit.html:54
 msgid "Profile photo"
 msgstr "Profilfoto"
 
-#: apps/account/templates/account/edit.html:65
-msgid ""
-"We automatically resize and compress PNG/JPEG uploads so they stay under 3 "
-"MB."
-msgstr ""
-"Wir ändern automatisch die Größe und komprimieren PNG-/JPEG-Uploads, damit "
-"sie unter 3 MB bleiben."
+msgid "We automatically resize and compress PNG/JPEG uploads so they stay under 3 MB."
+msgstr "Wir ändern automatisch die Größe und komprimieren PNG-/JPEG-Uploads, damit sie unter 3 MB bleiben."
 
-#: apps/account/templates/account/edit.html:73
 msgid "Remove your profile picture?"
 msgstr "Profilbild entfernen?"
 
-#: apps/account/templates/account/edit.html:76
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: apps/account/templates/account/edit.html:138
 msgid "Notification Center"
 msgstr "Benachrichtigungszentrum"
 
-#: apps/account/templates/account/edit.html:139
 msgid "Choose how you want to hear from us."
 msgstr "Wähle, wie du von uns hören möchtest."
 
-#: apps/account/templates/account/edit.html:189
 msgid "Need a new password?"
 msgstr "Neues Passwort benötigt?"
 
-#: apps/account/templates/account/edit.html:191
-msgid ""
-"Set a fresh password any time. We’ll keep you logged in while you update it."
-msgstr ""
-"Lege jederzeit ein neues Passwort fest. Wir halten dich während der "
-"Aktualisierung angemeldet."
+msgid "Set a fresh password any time. We’ll keep you logged in while you update it."
+msgstr "Lege jederzeit ein neues Passwort fest. Wir halten dich während der Aktualisierung angemeldet."
 
-#: apps/account/templates/account/forgot_password.html:12
-#: apps/account/templates/account/forgot_password.html:38
 msgid "Forgot password"
 msgstr "Passwort vergessen"
 
-#: apps/account/templates/account/forgot_password.html:13
 msgid "We'll send you a recovery link"
 msgstr "Wir senden dir einen Wiederherstellungslink"
 
-#: apps/account/templates/account/forgot_password.html:15
-msgid ""
-"Tell us which email address is linked to your account and we’ll do the rest."
-msgstr ""
-"Sag uns, welche E-Mail-Adresse mit deinem Konto verknüpft ist, und wir "
-"übernehmen den Rest."
+msgid "Tell us which email address is linked to your account and we’ll do the rest."
+msgstr "Sag uns, welche E-Mail-Adresse mit deinem Konto verknüpft ist, und wir übernehmen den Rest."
 
-#: apps/account/templates/account/forgot_password.html:24
 msgid "Back to login"
 msgstr "Zurück zur Anmeldung"
 
-#: apps/account/templates/account/forgot_password.html:37
 msgid "Need to reset your password?"
 msgstr "Möchtest du dein Passwort zurücksetzen?"
 
-#: apps/account/templates/account/forgot_password.html:48
 msgid "Request a new password"
 msgstr "Neues Passwort anfordern"
 
-#: apps/account/templates/account/invite_guest.html:8
 #, python-format
 msgid ""
 "\n"
@@ -415,325 +281,208 @@ msgstr ""
 "                    Lade %(invitee)s zu \"%(room)s\" ein\n"
 "                "
 
-#: apps/account/templates/account/invite_guest.html:34
 msgid "Send invite"
 msgstr "Einladung senden"
 
-#: apps/account/templates/account/list.html:146
 msgid "Room roster"
 msgstr "Raumteilnehmerliste"
 
-#: apps/account/templates/account/list.html:149
 #, python-format
 msgid "Everyone in %(room_name)s"
 msgstr "Alle in %(room_name)s"
 
-#: apps/account/templates/account/list.html:152
-msgid ""
-"Invite roommates, add guests, and keep tabs on who has already viewed the "
-"room."
-msgstr ""
-"Lade Mitbewohner ein, füge Gäste hinzu und behalte im Blick, wer den Raum "
-"bereits angesehen hat."
+msgid "Invite roommates, add guests, and keep tabs on who has already viewed the room."
+msgstr "Lade Mitbewohner ein, füge Gäste hinzu und behalte im Blick, wer den Raum bereits angesehen hat."
 
-#: apps/account/templates/account/list.html:155
-#: apps/transaction/templates/transaction/list.html:256
 msgid "Status"
 msgstr "Status"
 
-#: apps/account/templates/account/list.html:158
 msgid "Room closed"
 msgstr "Raum geschlossen"
 
-#: apps/account/templates/account/list.html:160
 msgid "Room open"
 msgstr "Raum geöffnet"
 
-#: apps/account/templates/account/list.html:177
 msgid "Add existing user"
 msgstr "Bestehenden Nutzer hinzufügen"
 
-#: apps/account/templates/account/list.html:207
 msgid "No one here yet"
 msgstr "Noch niemand hier"
 
-#: apps/account/templates/account/list.html:208
 msgid "Invite a roommate or add a guest to start splitting expenses."
-msgstr ""
-"Lade einen Mitbewohner ein oder füge einen Gast hinzu, um mit dem Aufteilen "
-"der Ausgaben zu beginnen."
+msgstr "Lade einen Mitbewohner ein oder füge einen Gast hinzu, um mit dem Aufteilen der Ausgaben zu beginnen."
 
-#: apps/account/templates/account/list.html:221
 #, python-format
 msgid "Limited view of %(room_name)s"
 msgstr "Eingeschränkte Ansicht von %(room_name)s"
 
-#: apps/account/templates/account/list.html:224
-msgid ""
-"Room members keep the roster private. Join the room to see who helps run "
-"this space."
-msgstr ""
-"Die Mitglieder des Raums halten die Mitgliederliste geheim. Tritt dem Raum "
-"bei, um zu sehen, wer diesen Raum mitbetreut."
+msgid "Room members keep the roster private. Join the room to see who helps run this space."
+msgstr "Die Mitglieder des Raums halten die Mitgliederliste geheim. Tritt dem Raum bei, um zu sehen, wer diesen Raum mitbetreut."
 
-#: apps/account/templates/account/list.html:231
 msgid "Request access or register to interact with this room."
-msgstr ""
-"Frage Zugang an oder registriere dich, um mit diesem Raum zu interagieren."
+msgstr "Frage Zugang an oder registriere dich, um mit diesem Raum zu interagieren."
 
-#: apps/account/templates/account/login.html:12
 msgid "Welcome back"
 msgstr "Willkommen zurück"
 
-#: apps/account/templates/account/login.html:13
 msgid "Keep your shared finances moving"
 msgstr "Halte eure gemeinsamen Finanzen in Bewegung"
 
-#: apps/account/templates/account/login.html:15
-msgid ""
-"Stay in the flow: avoid surprising logouts and finish your next journal in "
-"one session."
-msgstr ""
-"Bleib im Fluss: Vermeide überraschende Abmeldungen und beende dein nächstes "
-"Journal in einer Sitzung."
+msgid "Stay in the flow: avoid surprising logouts and finish your next journal in one session."
+msgstr "Bleib im Fluss: Vermeide überraschende Abmeldungen und beende dein nächstes Journal in einer Sitzung."
 
-#: apps/account/templates/account/login.html:24
 msgid "Create an account"
 msgstr "Konto erstellen"
 
-#: apps/account/templates/account/login.html:37
 msgid "Secure login"
 msgstr "Sichere Anmeldung"
 
-#: apps/account/templates/account/login.html:38
 msgid "Login"
 msgstr "Anmelden"
 
-#: apps/account/templates/account/login.html:49
 msgid "Password"
 msgstr "Passwort"
 
-#: apps/account/templates/account/login.html:56
 msgid "Stay signed in for 30 days"
 msgstr "Für 30 Tage angemeldet bleiben"
 
-#: apps/account/templates/account/login.html:58
 msgid "Your session stays active as long as you keep using the app."
 msgstr "Deine Sitzung bleibt aktiv, solange du die App weiter nutzt."
 
-#: apps/account/templates/account/login.html:67
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: apps/account/templates/account/login.html:72
 msgid "Log in"
 msgstr "Anmelden"
 
-#: apps/account/templates/account/login.html:74
-msgid ""
-"We renew your cookie while you stay active so normal usage does not log you "
-"out, and checking \"Stay signed in\" keeps you signed in for 30 days."
-msgstr ""
-"Wir erneuern dein Cookie, solange du aktiv bleibst, damit dich normale "
-"Nutzung nicht abmeldet, und mit aktivierter Option \"Angemeldet bleiben\" "
-"bleibst du 30 Tage angemeldet."
+msgid "We renew your cookie while you stay active so normal usage does not log you out, and checking \"Stay signed in\" keeps you signed in for 30 days."
+msgstr "Wir erneuern dein Cookie, solange du aktiv bleibst, damit dich normale Nutzung nicht abmeldet, und mit aktivierter Option \"Angemeldet bleiben\" bleibst du 30 Tage angemeldet."
 
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:13
 msgid "Unsubscribed"
 msgstr "Abgemeldet"
 
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:14
 msgid "You’re no longer receiving payment reminders."
 msgstr "Du erhältst keine Zahlungserinnerungen mehr."
 
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:16
 msgid "Oops"
 msgstr "Hoppla"
 
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:17
 msgid "We couldn’t process the unsubscribe."
 msgstr "Wir konnten die Abmeldung nicht verarbeiten."
 
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:24
-#: apps/templates/_side_menu.html:122
 msgid "Sign in"
 msgstr "Anmelden"
 
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:27
 msgid "Account settings"
 msgstr "Kontoeinstellungen"
 
-#: apps/account/templates/account/payment_reminder_unsubscribe.html:30
 msgid "You can always re-enable reminders from your notification settings."
-msgstr ""
-"Du kannst Erinnerungen jederzeit über deine Benachrichtigungseinstellungen "
-"wieder aktivieren."
+msgstr "Du kannst Erinnerungen jederzeit über deine Benachrichtigungseinstellungen wieder aktivieren."
 
-#: apps/account/templates/account/register.html:12
 msgid "Join yamsa"
 msgstr "yamsa beitreten"
 
-#: apps/account/templates/account/register.html:13
 msgid "Create shared clarity in your rooms"
 msgstr "Schaffe gemeinsame Klarheit in deinen Räumen"
 
-#: apps/account/templates/account/register.html:15
-msgid ""
-"Registering takes a minute and keeps every room, bill, and settlement in "
-"sync."
-msgstr ""
-"Die Registrierung dauert eine Minute und hält jeden Raum, jede Rechnung und "
-"jede Abrechnung synchron."
+msgid "Registering takes a minute and keeps every room, bill, and settlement in sync."
+msgstr "Die Registrierung dauert eine Minute und hält jeden Raum, jede Rechnung und jede Abrechnung synchron."
 
-#: apps/account/templates/account/register.html:19
-#: apps/room/templates/room/partials/_detail_who_are_you.html:36
 msgid "Already have an account?"
 msgstr "Bereits ein Konto?"
 
-#: apps/account/templates/account/register.html:25
 msgid "Login here!"
 msgstr "Hier anmelden!"
 
-#: apps/account/templates/account/register.html:38
 msgid "Start now"
 msgstr "Jetzt anfangen"
 
-#: apps/account/templates/account/register.html:39
 msgid "Register"
 msgstr "Registrieren"
 
-#: apps/account/templates/account/register.html:42
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:20
 msgid "Name"
 msgstr "Name"
 
-#: apps/account/templates/account/register.html:68
 msgid "User ID"
 msgstr "Benutzer-ID"
 
-#: apps/account/templates/account/register.html:76
 msgid "Is Guest"
 msgstr "Ist Gast"
 
-#: apps/account/templates/account/register.html:85
 msgid "Register now"
 msgstr "Jetzt registrieren"
 
-#: apps/account/views/user_login_view.py:18
 msgid "The combination of email and password does not match"
 msgstr "Die Kombination aus E-Mail und Passwort ist nicht korrekt"
 
-#: apps/config/settings.py:89
 msgid "English"
 msgstr "Englisch"
 
-#: apps/config/settings.py:90
 msgid "German"
 msgstr "Deutsch"
 
-#: apps/core/templates/core/_welcome.html:10
 msgid "Room activity timeline"
 msgstr "Aktivitätsverlauf des Raums"
 
-#: apps/core/templates/core/_welcome.html:11
 msgid "See transactions and changes at a glance"
 msgstr "Transaktionen und Änderungen auf einen Blick sehen"
 
-#: apps/core/templates/core/_welcome.html:13
-msgid ""
-"Every room update - expenses logged, settlements, highlights - lands here so "
-"you never miss a beat."
-msgstr ""
-"Jedes Raum-Update – erfasste Ausgaben, Abrechnungen, Highlights – landet "
-"hier, damit du nichts verpasst."
+msgid "Every room update - expenses logged, settlements, highlights - lands here so you never miss a beat."
+msgstr "Jedes Raum-Update – erfasste Ausgaben, Abrechnungen, Highlights – landet hier, damit du nichts verpasst."
 
-#: apps/core/templates/core/_welcome.html:17
 msgid "Auto-updated feed"
 msgstr "Automatisch aktualisierter Feed"
 
-#: apps/core/templates/core/_welcome.html:18
 msgid "Events appear in chronological order with the newest at the top."
-msgstr ""
-"Ereignisse erscheinen in chronologischer Reihenfolge, die Neuesten oben."
+msgstr "Ereignisse erscheinen in chronologischer Reihenfolge, die Neuesten oben."
 
-#: apps/core/templates/core/_welcome.html:31
 msgid "No updates yet"
 msgstr "Noch keine Aktualisierungen"
 
-#: apps/core/templates/core/_welcome.html:32
-msgid ""
-"Once roommates start logging expenses or changes, they will appear here."
-msgstr ""
-"Sobald Mitbewohner Ausgaben oder Änderungen erfassen, erscheinen sie hier."
+msgid "Once roommates start logging expenses or changes, they will appear here."
+msgstr "Sobald Mitbewohner Ausgaben oder Änderungen erfassen, erscheinen sie hier."
 
-#: apps/core/templates/core/base.html:5
-msgid ""
-"yamsa helps shared households track expenses, settle debts, and stay "
-"organized with collaborative rooms, dashboards, and notifications."
-msgstr ""
-"yamsa hilft Wohngemeinschaften dabei, Ausgaben zu verfolgen, Schulden "
-"auszugleichen und mit kollaborativen Räumen, Dashboards und "
-"Benachrichtigungen organisiert zu bleiben."
+msgid "yamsa helps shared households track expenses, settle debts, and stay organized with collaborative rooms, dashboards, and notifications."
+msgstr "yamsa hilft Wohngemeinschaften dabei, Ausgaben zu verfolgen, Schulden auszugleichen und mit kollaborativen Räumen, Dashboards und Benachrichtigungen organisiert zu bleiben."
 
-#: apps/core/templates/core/base.html:6
 msgid "yamsa, shared expenses, roommate app, bill splitting, dashboards"
-msgstr ""
-"yamsa, gemeinsame Ausgaben, Mitbewohner-App, Rechnungsteilung, Dashboards"
+msgstr "yamsa, gemeinsame Ausgaben, Mitbewohner-App, Rechnungsteilung, Dashboards"
 
-#: apps/core/templates/core/base.html:18
 msgid "yamsa"
 msgstr "yamsa"
 
-#: apps/currency/models.py:13 apps/debt/views/debt_export_view.py:16
-#: apps/transaction/templates/transaction/create.html:176
-#: apps/transaction/templates/transaction/edit.html:128
-#: apps/transaction/views/transaction_export_view.py:17
 msgid "Currency"
 msgstr "Währung"
 
-#: apps/currency/models.py:14
 msgid "Currencies"
 msgstr "Währungen"
 
-#: apps/debt/models/debt.py:35
 #, python-brace-format
 msgid "Settled: {debitor} owes {value}{currency} to {creditor}"
 msgstr "Beglichen: {debitor} schuldet {value}{currency} an {creditor}"
 
-#: apps/debt/models/debt.py:37
 #, python-brace-format
 msgid "{debitor} owes {value}{currency} to {creditor}"
 msgstr "{debitor} schuldet {value}{currency} an {creditor}"
 
-#: apps/debt/models/reminder_log.py:10
 msgid "Inactive debt reminder"
 msgstr "Erinnerung für inaktive Schulden"
 
-#: apps/debt/models/reminder_log.py:11
 msgid "Inactive room reminder"
 msgstr "Erinnerung für inaktiven Raum"
 
-#: apps/debt/models/reminder_log.py:21
 msgid "Reminder log"
 msgstr "Erinnerungsprotokoll"
 
-#: apps/debt/models/reminder_log.py:22
 msgid "Reminder logs"
 msgstr "Erinnerungsprotokolle"
 
-#: apps/debt/templates/debt/list.html:40
 msgid "Optimised debts"
 msgstr "Optimierte Schulden"
 
-#: apps/debt/templates/debt/list.html:42
-msgid ""
-"Track what is left to settle inside this room. Click the piggy-bank to mark "
-"a debt as paid."
-msgstr ""
-"Verfolge, was in diesem Raum noch ausgeglichen werden muss. Klicke auf das "
-"Sparschwein, um eine Schuld als bezahlt zu markieren."
+msgid "Track what is left to settle inside this room. Click the piggy-bank to mark a debt as paid."
+msgstr "Verfolge, was in diesem Raum noch ausgeglichen werden muss. Klicke auf das Sparschwein, um eine Schuld als bezahlt zu markieren."
 
-#: apps/debt/templates/debt/list.html:48
 #, python-format
 msgid ""
 "\n"
@@ -752,65 +501,47 @@ msgstr[1] ""
 "                        %(active_debt_count)s ausstehende Schulden\n"
 "                    "
 
-#: apps/debt/templates/debt/list.html:60 apps/debt/templates/debt/list.html:62
-#: apps/transaction/templates/transaction/list.html:295
-#: apps/transaction/templates/transaction/list.html:297
 msgid "Export CSV"
 msgstr "CSV exportieren"
 
-#: apps/debt/templates/debt/list.html:66
 msgid "View category breakdown"
 msgstr "Kategorienaufteilung anzeigen"
 
-#: apps/debt/templates/debt/list.html:73
 msgid "Break down spend"
 msgstr "Ausgaben aufschlüsseln"
 
-#: apps/debt/templates/debt/list.html:89
 msgid "Money overview"
 msgstr "Geldübersicht"
 
-#: apps/debt/templates/debt/list.html:90
 msgid "See how much each person has paid and who still owes what."
 msgstr "Sieh, wie viel jede Person bezahlt hat und wer noch was schuldet."
 
-#: apps/debt/templates/debt/list.html:104
 #, python-format
 msgid "%(debitor_display)s owes %(value)s%(currency)s to %(creditor_display)s"
-msgstr ""
-"%(debitor_display)s schuldet %(value)s%(currency)s an %(creditor_display)s"
+msgstr "%(debitor_display)s schuldet %(value)s%(currency)s an %(creditor_display)s"
 
-#: apps/debt/templates/debt/list.html:111
 #, python-format
 msgid "Settled on %(settled_at)s"
 msgstr "Am %(settled_at)s beglichen"
 
-#: apps/debt/templates/debt/list.html:116
 msgid "Tap the piggy-bank when this debt is paid off."
 msgstr "Tippe auf das Sparschwein, wenn diese Schuld beglichen ist."
 
-#: apps/debt/templates/debt/list.html:121
 msgid "Settled"
 msgstr "Beglichen"
 
-#: apps/debt/templates/debt/list.html:123
 msgid "Outstanding"
 msgstr "Ausstehend"
 
-#: apps/debt/templates/debt/list.html:131
-#: apps/debt/tests/test_views/test_debt_list_view.py:84
 msgid "No debts yet"
 msgstr "Noch keine Schulden"
 
-#: apps/debt/templates/debt/list.html:132
 msgid "As expenses are added, we will surface who owes whom here."
 msgstr "Wenn Ausgaben hinzukommen, zeigen wir hier, wer wem etwas schuldet."
 
-#: apps/debt/templates/debt/partials/_settle_debt_piggy_icon.html:19
 msgid "This transaction is not yours to settle!"
 msgstr "Diese Transaktion darfst du nicht ausgleichen!"
 
-#: apps/debt/templates/debt/settle.html:7
 #, python-format
 msgid ""
 "\n"
@@ -821,842 +552,563 @@ msgstr ""
 "                    Deine Schuld an %(creditor_name)s\n"
 "                "
 
-#: apps/debt/templates/debt/settle.html:12
 #, python-format
 msgid ""
 "\n"
-"                    Are you sure that you have settled your debt "
-"(%(debt_value)s%(debt_currency)s)\n"
+"                    Are you sure that you have settled your debt (%(debt_value)s%(debt_currency)s)\n"
 "                    to %(creditor_name)s?\n"
 "                "
 msgstr ""
 "\n"
-"                    Bist du sicher, dass du deine Schuld "
-"(%(debt_value)s%(debt_currency)s)\n"
+"                    Bist du sicher, dass du deine Schuld (%(debt_value)s%(debt_currency)s)\n"
 "                    bei %(creditor_name)s beglichen hast?\n"
 "                "
 
-#: apps/debt/templates/debt/settle.html:28
 msgid "Debt ID"
 msgstr "Schulden-ID"
 
-#: apps/debt/templates/debt/settle.html:37
 msgid "Settled?"
 msgstr "Beglichen?"
 
-#: apps/debt/templates/debt/settle.html:52
 msgid "No, take me to their paypal"
 msgstr "Nein, bring mich zu ihrem PayPal"
 
-#: apps/debt/templates/debt/settle.html:61
 msgid "No action available"
 msgstr "Keine Aktion möglich"
 
-#: apps/debt/templates/debt/settle.html:61
 msgid "No"
 msgstr "Nein"
 
-#: apps/debt/templates/debt/settle.html:65
 msgid "Yes"
 msgstr "Ja"
 
-#: apps/debt/views/debt_export_view.py:16
 msgid "Debitor"
 msgstr "Schuldner"
 
-#: apps/debt/views/debt_export_view.py:16
 msgid "Creditor"
 msgstr "Gläubiger"
 
-#: apps/debt/views/debt_export_view.py:16
-#: apps/transaction/templates/transaction/child_transaction_create.html:5
-#: apps/transaction/templates/transaction/edit.html:226
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:17
-#: apps/transaction/views/transaction_export_view.py:17
 msgid "Amount"
 msgstr "Betrag"
 
-#: apps/debt/views/debt_export_view.py:28
 msgid "debts"
 msgstr "schulden"
 
-#: apps/mail/services/base_email_service/email_base_text_context.py:13
 msgid "yamsa | Yet another money split app"
 msgstr "yamsa | Noch eine App zum Geldteilen"
 
-#: apps/mail/services/base_email_service/email_user_text_context.py:10
 msgid "Hey"
 msgstr "Hey"
 
-#: apps/mail/services/forgot_password_mail_service.py:9
 msgid "New Password"
 msgstr "Neues Passwort"
 
-#: apps/mail/services/forgot_password_mail_service.py:14
 msgid "Log in with new password"
 msgstr "Mit neuem Passwort anmelden"
 
-#: apps/mail/services/forgot_password_mail_service.py:21
 msgid "Forgotten your password?"
 msgstr "Passwort vergessen?"
 
-#: apps/mail/services/forgot_password_mail_service.py:22
 msgid "No worries - happens to the best!"
 msgstr "Keine Sorge – passiert den Besten!"
 
-#: apps/mail/services/forgot_password_mail_service.py:24
 msgid "Your new password is:"
 msgstr "Dein neues Passwort lautet:"
 
-#: apps/mail/services/forgot_password_mail_service.py:27
 msgid "Log in with your new password, by clicking the button below"
-msgstr ""
-"Melde dich mit deinem neuen Passwort an, indem du auf den Button unten "
-"klickst"
+msgstr "Melde dich mit deinem neuen Passwort an, indem du auf den Button unten klickst"
 
-#: apps/mail/services/forgot_password_mail_service.py:28
 msgid "(And don't forget to change your password afterwards!)"
 msgstr "(Und vergiss nicht, dein Passwort danach zu ändern!)"
 
-#: apps/mail/services/invitation_mail_service.py:12
 msgid "Invitation"
 msgstr "Einladung"
 
-#: apps/mail/services/invitation_mail_service.py:21
 #, python-format
 msgid "You have been invited by %(inviter)s to join your friends on yamsa"
-msgstr ""
-"Du wurdest von %(inviter)s eingeladen, dich deinen Freunden auf yamsa "
-"anzuschließen"
+msgstr "Du wurdest von %(inviter)s eingeladen, dich deinen Freunden auf yamsa anzuschließen"
 
-#: apps/mail/services/invitation_mail_service.py:26
 msgid "Click the button below to register!"
 msgstr "Klicke auf den Button unten, um dich zu registrieren!"
 
-#: apps/mail/services/invitation_mail_service.py:34
 msgid "Register here"
 msgstr "Hier registrieren"
 
-#: apps/mail/services/payment_reminder_mail_service.py:24
 #, python-format
 msgid "%(room_name)s | Payment reminder"
 msgstr "%(room_name)s | Zahlungserinnerung"
 
-#: apps/mail/services/payment_reminder_mail_service.py:30
 #, python-format
-msgid ""
-"Hey there! It has been %(inactivity_days)d days since any activity in "
-"%(room_name)s."
-msgstr ""
-"Hallo! Es sind %(inactivity_days)d Tage seit der letzten Aktivität in "
-"%(room_name)s vergangen."
+msgid "Hey there! It has been %(inactivity_days)d days since any activity in %(room_name)s."
+msgstr "Hallo! Es sind %(inactivity_days)d Tage seit der letzten Aktivität in %(room_name)s vergangen."
 
-#: apps/mail/services/payment_reminder_mail_service.py:35
 #, python-format
 msgid "You currently owe %(amount_summary)s."
 msgstr "Du schuldest aktuell %(amount_summary)s."
 
-#: apps/mail/services/payment_reminder_mail_service.py:39
-msgid ""
-"Please follow the link below to review and settle the outstanding balance "
-"before it grows stale."
-msgstr ""
-"Bitte folge dem Link unten, um den offenen Betrag zu prüfen und zu "
-"begleichen, bevor er veraltet."
+msgid "Please follow the link below to review and settle the outstanding balance before it grows stale."
+msgstr "Bitte folge dem Link unten, um den offenen Betrag zu prüfen und zu begleichen, bevor er veraltet."
 
-#: apps/mail/services/payment_reminder_mail_service.py:46
 #, python-format
 msgid "Payment reminder: %(room_name)s"
 msgstr "Zahlungserinnerung: %(room_name)s"
 
-#: apps/mail/services/payment_reminder_mail_service.py:47
-msgid ""
-"This reminder is generated automatically for overdue balances. We're "
-"cheering for you!"
-msgstr ""
-"Diese Erinnerung wird automatisch bei überfälligen Beträgen erzeugt. Wir "
-"drücken dir die Daumen!"
+msgid "This reminder is generated automatically for overdue balances. We're cheering for you!"
+msgstr "Diese Erinnerung wird automatisch bei überfälligen Beträgen erzeugt. Wir drücken dir die Daumen!"
 
-#: apps/mail/services/payment_reminder_mail_service.py:48
 msgid "Need a hand? Reach out to your room admin if the numbers look off."
-msgstr ""
-"Brauchst du Unterstützung? Wende dich an den Raum-Admin, wenn die Zahlen "
-"nicht stimmen."
+msgstr "Brauchst du Unterstützung? Wende dich an den Raum-Admin, wenn die Zahlen nicht stimmen."
 
-#: apps/mail/services/payment_reminder_mail_service.py:60
 msgid "Review pending debts"
 msgstr "Ausstehende Schulden prüfen"
 
-#: apps/mail/services/post_register_mail_service.py:10
-#: apps/mail/services/post_register_mail_service.py:20
 msgid "Welcome to yamsa"
 msgstr "Willkommen bei yamsa"
 
-#: apps/mail/services/post_register_mail_service.py:23
 msgid "It looks like you already belong to some rooms!"
 msgstr "Es sieht so aus, als würdest du bereits zu einigen Räumen gehören!"
 
-#: apps/mail/services/post_register_mail_service.py:24
 msgid "Check them out, by clicking the button below"
 msgstr "Schau sie dir an, indem du auf den Button unten klickst"
 
-#: apps/mail/services/post_register_mail_service.py:26
 msgid "Create a new room, by clicking the button below"
 msgstr "Erstelle einen neuen Raum, indem du auf den Button unten klickst"
 
-#: apps/mail/services/post_register_mail_service.py:32
 msgid "Create a room"
 msgstr "Einen Raum erstellen"
 
-#: apps/mail/services/post_register_mail_service.py:36
 msgid "See your rooms"
 msgstr "Deine Räume ansehen"
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:23
 #, python-format
 msgid "%(room_name)s | Room still open?"
 msgstr "%(room_name)s | Raum noch offen?"
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:29
 #, python-format
 msgid "%(room_name)s has been quiet for %(inactivity_days)d days."
 msgstr "%(room_name)s war seit %(inactivity_days)d Tagen inaktiv."
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:36
-msgid ""
-"If everyone already settled up, please mark the debts as paid and close the "
-"room so it stops lingering."
-msgstr ""
-"Wenn alle bereits abgerechnet haben, markiere die Schulden bitte als bezahlt "
-"und schließe den Raum, damit er nicht weiter offen bleibt."
+msgid "If everyone already settled up, please mark the debts as paid and close the room so it stops lingering."
+msgstr "Wenn alle bereits abgerechnet haben, markiere die Schulden bitte als bezahlt und schließe den Raum, damit er nicht weiter offen bleibt."
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:40
-msgid ""
-"If you still need the room, feel free to ignore this reminder and keep it "
-"open."
-msgstr ""
-"Wenn du den Raum noch brauchst, ignoriere diese Erinnerung und lasse ihn "
-"geöffnet."
+msgid "If you still need the room, feel free to ignore this reminder and keep it open."
+msgstr "Wenn du den Raum noch brauchst, ignoriere diese Erinnerung und lasse ihn geöffnet."
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:46
 #, python-format
 msgid "Room cleanup reminder: %(room_name)s"
 msgstr "Erinnerung zur Raumbereinigung: %(room_name)s"
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:47
-msgid ""
-"This reminder is generated automatically when open rooms stay inactive. "
-"We're happy to help."
-msgstr ""
-"Diese Erinnerung wird automatisch erzeugt, wenn offene Räume inaktiv "
-"bleiben. Wir helfen gern."
+msgid "This reminder is generated automatically when open rooms stay inactive. We're happy to help."
+msgstr "Diese Erinnerung wird automatisch erzeugt, wenn offene Räume inaktiv bleiben. Wir helfen gern."
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:48
 msgid "Give us a shout if the room history looks off."
 msgstr "Melde dich, wenn die Raumhistorie nicht stimmt."
 
-#: apps/mail/services/room_closure_reminder_mail_service.py:60
 msgid "Review room status"
 msgstr "Raumstatus prüfen"
 
-#: apps/mail/services/user_added_to_room_mail_service.py:17
 #, python-format
 msgid "Welcome to %(room_name)s"
 msgstr "Willkommen bei %(room_name)s"
 
-#: apps/mail/services/user_added_to_room_mail_service.py:22
 #, python-format
 msgid "You have been invited to %(room_name)s to join your friends"
-msgstr ""
-"Du wurdest eingeladen, dich deinen Freunden in %(room_name)s anzuschließen"
+msgstr "Du wurdest eingeladen, dich deinen Freunden in %(room_name)s anzuschließen"
 
-#: apps/mail/services/user_added_to_room_mail_service.py:24
 msgid "Click the button below to view the room!"
 msgstr "Klicke auf den Button unten, um den Raum zu sehen!"
 
-#: apps/mail/services/user_added_to_room_mail_service.py:33
 msgid "See the room"
 msgstr "Raum ansehen"
 
-#: apps/news/handlers/events/create_news_on_room_created.py:13
 #, python-brace-format
 msgid "{creator} created \"{room_name}\""
 msgstr "{creator} hat \"{room_name}\" erstellt"
 
-#: apps/news/handlers/events/create_news_on_transaction_create.py:13
 #, python-brace-format
 msgid "{payer} paid {amount}{currency} in \"{room}\""
 msgstr "{payer} hat {amount}{currency} in \"{room}\" bezahlt"
 
-#: apps/news/handlers/events/create_news_on_transaction_delete.py:12
 #, python-brace-format
-msgid ""
-"{actor} deleted the transaction \"{description}\" ({amount}{currency}) in "
-"\"{room}\""
-msgstr ""
-"{actor} hat die Transaktion \"{description}\" ({amount}{currency}) in "
-"\"{room}\" gelöscht"
+msgid "{actor} deleted the transaction \"{description}\" ({amount}{currency}) in \"{room}\""
+msgstr "{actor} hat die Transaktion \"{description}\" ({amount}{currency}) in \"{room}\" gelöscht"
 
-#: apps/news/handlers/events/create_news_on_transaction_delete.py:21
 #, python-brace-format
 msgid "{icon} {initials}: Transaction deleted"
 msgstr "{icon} {initials}: Transaktion gelöscht"
 
-#: apps/news/handlers/events/create_news_on_user_connection_to_room_created.py:14
 msgid "themselves"
 msgstr "sich selbst"
 
-#: apps/news/handlers/events/create_news_on_user_connection_to_room_created.py:16
 msgid "System"
 msgstr "System"
 
-#: apps/news/handlers/events/create_news_on_user_connection_to_room_created.py:17
 #, python-brace-format
 msgid "{created_by} added {added_user} to \"{room_name}\""
 msgstr "{created_by} hat {added_user} zu \"{room_name}\" hinzugefügt"
 
-#: apps/news/models.py:12
 msgid "Room created"
 msgstr "Raum erstellt"
 
-#: apps/news/models.py:13
 msgid "Transaction created"
 msgstr "Transaktion erstellt"
 
-#: apps/news/models.py:14
 msgid "Transaction deleted"
 msgstr "Transaktion gelöscht"
 
-#: apps/news/models.py:15
 msgid "User added"
 msgstr "Nutzer:in hinzugefügt"
 
-#: apps/news/models.py:31
 msgid "News update"
 msgstr "News Update"
 
-#: apps/news/models.py:63 apps/news/models.py:64
 msgid "News"
 msgstr "Neuigkeiten"
 
-#: apps/room/models/room.py:17 apps/room/templates/room/detail.html:17
-#: apps/templates/_side_menu_room_list.html:4
-#: apps/transaction/templates/transaction/list.html:261
 msgid "Open"
 msgstr "Offen"
 
-#: apps/room/models/room.py:18 apps/room/templates/room/detail.html:15
-#: apps/room/templates/room/partials/_detail_who_are_you.html:13
-#: apps/templates/_side_menu_room_list.html:52
-#: apps/transaction/templates/transaction/list.html:259
 msgid "Closed"
 msgstr "Geschlossen"
 
-#: apps/room/models/room.py:36
-#: apps/room/templates/room/partials/_detail_who_are_you.html:76
-#: apps/transaction/templates/transaction/create.html:272
 msgid "Room"
 msgstr "Raum"
 
-#: apps/room/models/room.py:37
 msgid "Rooms"
 msgstr "Räume"
 
-#: apps/room/models/user_connection_to_room.py:20
 #, python-brace-format
 msgid "{user} belongs to {room}"
 msgstr "{user} gehört zu {room}"
 
-#: apps/room/templates/room/create.html:15
-#: apps/room/templates/room/create.html:22
 msgid "Back to dashboard"
 msgstr "Zurück zum Dashboard"
 
-#: apps/room/templates/room/create.html:24
 msgid "Create Room"
 msgstr "Raum erstellen"
 
-#: apps/room/templates/room/create.html:61
-#: apps/templates/_side_menu_room_list.html:48
 msgid "Create"
 msgstr "Erstellen"
 
-#: apps/room/templates/room/create.html:71
 msgid "Suggested guests"
 msgstr "Vorgeschlagene Gäste"
 
-#: apps/room/templates/room/create.html:72
 msgid "Invite frequent collaborators"
 msgstr "Lade häufige Mitwirkende ein"
 
-#: apps/room/templates/room/create.html:74
-msgid ""
-"Add past roommates with one tap. Mark your go-to teammates as friends to pin "
-"them to the top."
-msgstr ""
-"Füge frühere Mitbewohner mit einem Tippen hinzu. Markiere deine bevorzugten "
-"Teammitglieder als Freunde, um sie oben anzupinnen."
+msgid "Add past roommates with one tap. Mark your go-to teammates as friends to pin them to the top."
+msgstr "Füge frühere Mitbewohner mit einem Tippen hinzu. Markiere deine bevorzugten Teammitglieder als Freunde, um sie oben anzupinnen."
 
-#: apps/room/templates/room/detail.html:9
 msgid "Room overview"
 msgstr "Raumübersicht"
 
-#: apps/room/templates/room/detail.html:11
 msgid "No description added yet."
 msgstr "Noch keine Beschreibung hinzugefügt."
 
-#: apps/room/templates/room/detail.html:20
-#: apps/room/templates/room/detail.html:39
 msgid "Preferred currency"
 msgstr "Bevorzugte Währung"
 
-#: apps/room/templates/room/detail.html:31
 msgid "Edit room"
 msgstr "Raum bearbeiten"
 
-#: apps/room/templates/room/detail.html:41
 msgid "Used as the default for new transactions."
 msgstr "Wird als Standard für neue Transaktionen verwendet."
 
-#: apps/room/templates/room/detail.html:46
 msgid "Members"
 msgstr "Mitglieder"
 
-#: apps/room/templates/room/detail.html:48
 msgid "Roommates and guests currently connected."
 msgstr "Derzeit verbundene Mitbewohner und Gäste."
 
-#: apps/room/templates/room/detail.html:53
 msgid "Closing readiness"
 msgstr "Schließbereitschaft"
 
-#: apps/room/templates/room/detail.html:55
 msgid "Ready to close"
 msgstr "Bereit zum Schließen"
 
-#: apps/room/templates/room/detail.html:56
 msgid "No unsettled debts remain."
 msgstr "Es bleiben keine offenen Schulden."
 
-#: apps/room/templates/room/detail.html:58
 msgid "Outstanding balances"
 msgstr "Ausstehende Salden"
 
-#: apps/room/templates/room/detail.html:59
 msgid "Settle open debts before closing."
 msgstr "Begleiche offene Schulden vor dem Schließen."
 
-#: apps/room/templates/room/detail.html:66
 msgid "Keep logging expenses and invite more people whenever you need to."
 msgstr "Erfasse weiterhin Ausgaben und lade bei Bedarf weitere Menschen ein."
 
-#: apps/room/templates/room/detail.html:68
-msgid ""
-"This room is locked for editing. Reopen it from the edit screen if you need "
-"to make changes."
-msgstr ""
-"Dieser Raum ist zur Bearbeitung gesperrt. Öffne ihn auf dem "
-"Bearbeitungsbildschirm, wenn du Änderungen brauchst."
+msgid "This room is locked for editing. Reopen it from the edit screen if you need to make changes."
+msgstr "Dieser Raum ist zur Bearbeitung gesperrt. Öffne ihn auf dem Bearbeitungsbildschirm, wenn du Änderungen brauchst."
 
-#: apps/room/templates/room/edit.html:5
 msgid "Back to room"
 msgstr "Zurück zum Raum"
 
-#: apps/room/templates/room/edit.html:6
 msgid "Save room details"
 msgstr "Raumdetails speichern"
 
-#: apps/room/templates/room/edit.html:7
-#: apps/templates/shared_partials/toast.html:2
 msgid "Close"
 msgstr "Schließen"
 
-#: apps/room/templates/room/edit.html:22
-#: apps/transaction/templates/transaction/category_manager.html:7
 msgid "Room settings"
 msgstr "Raumeinstellungen"
 
-#: apps/room/templates/room/edit.html:24
 #, python-format
 msgid "Edit \"%(room_name)s\""
 msgstr "\"%(room_name)s\" bearbeiten"
 
-#: apps/room/templates/room/edit.html:45
 msgid "Basics"
 msgstr "Grundlagen"
 
-#: apps/room/templates/room/edit.html:46
 msgid "Name, description & currency"
 msgstr "Name, Beschreibung & Währung"
 
-#: apps/room/templates/room/edit.html:48
 msgid "Please fix the highlighted errors in the form."
 msgstr "Bitte behebe die markierten Fehler im Formular."
 
-#: apps/room/templates/room/edit.html:112
 msgid "Room status"
 msgstr "Raumstatus"
 
-#: apps/room/templates/room/edit.html:116
 msgid "All debts are settled. You can close the room."
 msgstr "Alle Schulden sind beglichen. Du kannst den Raum schließen."
 
-#: apps/room/templates/room/edit.html:119
 #, python-format
 msgid ""
 "\n"
-"                                            There is still %(debt_count)s "
-"open debt.\n"
+"                                            There is still %(debt_count)s open debt.\n"
 "                                        "
 msgid_plural ""
 "\n"
-"                                            There are still %(debt_count)s "
-"open debts.\n"
+"                                            There are still %(debt_count)s open debts.\n"
 "                                        "
 msgstr[0] ""
 "\n"
-"                                            Es gibt noch %(debt_count)s "
-"offene Schuld.\n"
+"                                            Es gibt noch %(debt_count)s offene Schuld.\n"
 "                                        "
 msgstr[1] ""
 "\n"
-"                                            Es gibt noch %(debt_count)s "
-"offene Schulden.\n"
+"                                            Es gibt noch %(debt_count)s offene Schulden.\n"
 "                                        "
 
-#: apps/room/templates/room/edit.html:127
 msgid "The room is closed and can be reopened."
 msgstr "Der Raum ist geschlossen und kann wieder geöffnet werden."
 
-#: apps/room/templates/room/edit.html:152
-#: apps/room/templates/room/edit.html:160
 msgid "Close room"
 msgstr "Raum schließen"
 
-#: apps/room/templates/room/edit.html:167
 msgid "Reopen room"
 msgstr "Raum wieder öffnen"
 
-#: apps/room/templates/room/edit.html:186
 msgid "Category manager"
 msgstr "Kategorie-Manager"
 
-#: apps/room/templates/room/edit.html:187
 msgid "Customize tracking categories"
 msgstr "Tracking-Kategorien anpassen"
 
-#: apps/room/templates/room/edit.html:189
-msgid ""
-"Add room-specific categories and control their order without touching the "
-"global defaults."
-msgstr ""
-"Füge raumspezifische Kategorien hinzu und steuere deren Reihenfolge, ohne "
-"die globalen Standardeinstellungen zu verändern."
+msgid "Add room-specific categories and control their order without touching the global defaults."
+msgstr "Füge raumspezifische Kategorien hinzu und steuere deren Reihenfolge, ohne die globalen Standardeinstellungen zu verändern."
 
-#: apps/room/templates/room/edit.html:200
 msgid "Open manager"
 msgstr "Manager öffnen"
 
-#: apps/room/templates/room/edit.html:216
 msgid "Outstanding debts"
 msgstr "Ausstehende Schulden"
 
-#: apps/room/templates/room/edit.html:217
 msgid "This room still has outstanding payments."
 msgstr "Dieser Raum hat noch ausstehende Zahlungen."
 
-#: apps/room/templates/room/edit.html:226
 #, python-format
 msgid ""
 "\n"
-"                                    There is still %(debt_count)s open debt. "
-"Closing the room anyway will mark it as settled.\n"
+"                                    There is still %(debt_count)s open debt. Closing the room anyway will mark it as settled.\n"
 "                                "
 msgid_plural ""
 "\n"
-"                                    There are still %(debt_count)s open "
-"debts. Closing the room anyway will mark them as settled.\n"
+"                                    There are still %(debt_count)s open debts. Closing the room anyway will mark them as settled.\n"
 "                                "
 msgstr[0] ""
 "\n"
-"                                    Es gibt noch %(debt_count)s offene "
-"Schuld. Wenn du den Raum trotzdem schließt, wird sie als beglichen "
-"markiert.\n"
+"                                    Es gibt noch %(debt_count)s offene Schuld. Wenn du den Raum trotzdem schließt, wird sie als beglichen markiert.\n"
 "                                "
 msgstr[1] ""
 "\n"
-"                                    Es gibt noch %(debt_count)s offene "
-"Schulden. Wenn du den Raum trotzdem schließt, werden sie als beglichen "
-"markiert.\n"
+"                                    Es gibt noch %(debt_count)s offene Schulden. Wenn du den Raum trotzdem schließt, werden sie als beglichen markiert.\n"
 "                                "
 
-#: apps/room/templates/room/edit.html:232
 msgid "Use this option only if you want to skip manual settlement."
-msgstr ""
-"Nutze diese Option nur, wenn du die manuelle Abrechnung überspringen "
-"möchtest."
+msgstr "Nutze diese Option nur, wenn du die manuelle Abrechnung überspringen möchtest."
 
-#: apps/room/templates/room/edit.html:238
 msgid "Close anyway"
 msgstr "Trotzdem schließen"
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:15
 msgid "Open to guests"
 msgstr "Für Gäste offen"
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:20
-msgid ""
-"Maybe register? A free account keeps your rooms, reminders, and history "
-"together."
-msgstr ""
-"Vielleicht registrieren? Ein kostenloses Konto hält deine Räume, "
-"Erinnerungen und Historie zusammen."
+msgid "Maybe register? A free account keeps your rooms, reminders, and history together."
+msgstr "Vielleicht registrieren? Ein kostenloses Konto hält deine Räume, Erinnerungen und Historie zusammen."
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:29
 msgid "Claim your invitation"
 msgstr "Einladung annehmen"
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:31
-msgid ""
-"Guests who arrive via the shared link can register or log in here to confirm "
-"their spot."
-msgstr ""
-"Gäste, die über den geteilten Link kommen, können sich hier registrieren "
-"oder anmelden, um ihren Platz zu bestätigen."
+msgid "Guests who arrive via the shared link can register or log in here to confirm their spot."
+msgstr "Gäste, die über den geteilten Link kommen, können sich hier registrieren oder anmelden, um ihren Platz zu bestätigen."
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:47
 msgid "Who are you?"
 msgstr "Wer bist du?"
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:64
-#: apps/room/templates/room/partials/_detail_who_are_you.html:69
-msgid ""
-"Only Guest Users of the room are shown here. If you do not see your name, "
-"that means that you either are not part of this room or that you already "
-"have an account. If you already have an account, try logging in."
-msgstr ""
-"Nur Gastnutzer:innen des Raums werden hier angezeigt. Wenn du deinen Namen "
-"nicht siehst, bist du entweder nicht Teil dieses Raums oder hast bereits ein "
-"Konto. Wenn du schon ein Konto hast, versuche dich einzuloggen."
+msgid "Only Guest Users of the room are shown here. If you do not see your name, that means that you either are not part of this room or that you already have an account. If you already have an account, try logging in."
+msgstr "Nur Gastnutzer:innen des Raums werden hier angezeigt. Wenn du deinen Namen nicht siehst, bist du entweder nicht Teil dieses Raums oder hast bereits ein Konto. Wenn du schon ein Konto hast, versuche dich einzuloggen."
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:66
 msgid "Not seeing your name?"
 msgstr "Siehst du deinen Namen nicht?"
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:85
 msgid "That's me!"
 msgstr "Das bin ich!"
 
-#: apps/room/templates/room/partials/_detail_who_are_you.html:90
-msgid ""
-"No guests have been invited yet. Create an account to add yourself to the "
-"room."
-msgstr ""
-"Es wurden noch keine Gäste eingeladen. Erstelle ein Konto, um dich selbst "
-"zum Raum hinzuzufügen."
+msgid "No guests have been invited yet. Create an account to add yourself to the room."
+msgstr "Es wurden noch keine Gäste eingeladen. Erstelle ein Konto, um dich selbst zum Raum hinzuzufügen."
 
-#: apps/templates/_side_menu.html:2
 msgid "Toggle navigation"
 msgstr "Navigation umschalten"
 
-#: apps/templates/_side_menu.html:3
 msgid "Copy the rooms URL to your clipboard to send it to your friends"
-msgstr ""
-"Kopiere die Raum-URL in die Zwischenablage, um sie deinen Freunden zu "
-"schicken"
+msgstr "Kopiere die Raum-URL in die Zwischenablage, um sie deinen Freunden zu schicken"
 
-#: apps/templates/_side_menu.html:60
 msgid "Menu"
 msgstr "Menü"
 
-#: apps/templates/_side_menu.html:98
 msgid "Profile"
 msgstr "Profil"
 
-#: apps/templates/_side_menu.html:105
 msgid "Log in to access rooms"
 msgstr "Melde dich an, um Räume zu nutzen"
 
-#: apps/templates/_side_menu.html:107
 msgid "Manage rooms and transactions"
 msgstr "Räume und Transaktionen verwalten"
 
-#: apps/templates/_side_menu.html:124
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: apps/templates/_side_menu.html:142
 msgid "Home"
 msgstr "Startseite"
 
-#: apps/templates/_side_menu.html:143
 msgid "Back to home"
 msgstr "Zur Startseite"
 
-#: apps/templates/_side_menu.html:145
 msgid "Start"
 msgstr "Start"
 
-#: apps/templates/_side_menu.html:156
 msgid "Log out"
 msgstr "Abmelden"
 
-#: apps/templates/_side_menu_room_list.html:32
 msgid "New"
 msgstr "Neu"
 
-#: apps/templates/_side_menu_room_list.html:45
 msgid "New room"
 msgstr "Neuer Raum"
 
-#: apps/templates/_side_menu_room_list.html:46
 msgid "Start a new group with friends"
 msgstr "Starte eine neue Gruppe mit Freunden"
 
-#: apps/templates/_side_menu_room_list.html:81
 msgid "Other"
 msgstr "Andere"
 
-#: apps/templates/shared_partials/loading_spinner.html:6
 msgid "Loading..."
 msgstr "Wird geladen..."
 
-#: apps/templates/shared_partials/member_form.html:118
 msgid "Back"
 msgstr "Zurück"
 
-#: apps/templates/shared_partials/member_form.html:129
 msgid "Room access"
 msgstr "Raumzugang"
 
-#: apps/templates/shared_partials/member_form.html:141
 msgid "New member"
 msgstr "Neues Mitglied"
 
-#: apps/templates/shared_partials/member_form.html:182
 msgid "We'll notify members automatically."
 msgstr "Wir benachrichtigen die Mitglieder automatisch."
 
-#: apps/templates/shared_partials/member_form.html:192
 msgid "Submit"
 msgstr "Absenden"
 
-#: apps/templates/shared_partials/member_form.html:198
 msgid "This room is closed, so new members cannot be added."
-msgstr ""
-"Dieser Raum ist geschlossen, daher können keine neuen Mitglieder hinzugefügt "
-"werden."
+msgstr "Dieser Raum ist geschlossen, daher können keine neuen Mitglieder hinzugefügt werden."
 
-#: apps/templates/shared_partials/news_batch.html:6
 msgid "No updates yet."
 msgstr "Noch keine Updates."
 
-#: apps/templates/shared_partials/news_batch.html:36
 msgid "You are all caught up."
 msgstr "Du bist auf dem Laufenden."
 
-#: apps/templates/shared_partials/news_card.html:4
 msgid "Open related update"
 msgstr "Verwandtes Update öffnen"
 
-#: apps/templates/shared_partials/news_card.html:15
-#: apps/templates/shared_partials/news_card.html:34
 msgid "Update"
 msgstr "Aktualisierung"
 
-#: apps/templates/shared_partials/news_card.html:19
-#: apps/templates/shared_partials/news_card.html:38
 #, python-format
 msgid "%(timesince)s ago"
 msgstr "vor %(timesince)s"
 
-#: apps/templates/shared_partials/toast.html:27
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
-#: apps/templates/shared_partials/user_card.html:3
 msgid "Remove from room"
 msgstr "Aus dem Raum entfernen"
 
-#: apps/templates/shared_partials/user_card.html:30
 msgid "Guest"
 msgstr "Gast"
 
-#: apps/templates/shared_partials/user_card.html:32
 msgid "Member"
 msgstr "Mitglied"
 
-#: apps/templates/shared_partials/user_card.html:37
 msgid "Seen room"
 msgstr "Raum gesehen"
 
-#: apps/templates/shared_partials/user_card.html:39
 msgid "Not seen yet"
 msgstr "Noch nicht gesehen"
 
-#: apps/templates/shared_partials/user_card.html:45
-msgid ""
-"Are you sure you want to remove yourself from this room? You will not be "
-"able to see this room afterwards anymore!"
-msgstr ""
-"Bist du sicher, dass du dich aus diesem Raum entfernen möchtest? Danach "
-"kannst du ihn nicht mehr sehen!"
+msgid "Are you sure you want to remove yourself from this room? You will not be able to see this room afterwards anymore!"
+msgstr "Bist du sicher, dass du dich aus diesem Raum entfernen möchtest? Danach kannst du ihn nicht mehr sehen!"
 
-#: apps/templates/shared_partials/user_card.html:47
 msgid "Are you sure you wish to remove this user from this room?"
-msgstr ""
-"Bist du sicher, dass du diesen Nutzer aus diesem Raum entfernen möchtest?"
+msgstr "Bist du sicher, dass du diesen Nutzer aus diesem Raum entfernen möchtest?"
 
-#: apps/templates/shared_partials/user_card.html:64
 msgid "Guest access with limited features"
 msgstr "Gastzugang mit eingeschränkten Funktionen"
 
-#: apps/templates/shared_partials/user_card.html:66
 msgid "Registered roommate"
 msgstr "Registrierter Mitbewohner"
 
-#: apps/templates/shared_partials/user_card.html:82
 msgid "Joined as a full member of this room."
 msgstr "Als volles Mitglied dieses Raums beigetreten."
 
-#: apps/transaction/forms/room_category_forms/room_category_create_form.py:14
 msgid "Enter a color in #RRGGBB format."
 msgstr "Gib eine Farbe im Format #RRGGBB ein."
 
-#: apps/transaction/forms/room_category_forms/validators.py:9
-#: apps/transaction/forms/room_category_forms/validators.py:13
-#: apps/transaction/forms/room_category_forms/validators.py:19
 msgid "Enter a single emoji character."
 msgstr "Gib ein einzelnes Emoji-Zeichen ein."
 
-#: apps/transaction/models/child_transaction.py:22
 #, python-brace-format
 msgid "{paid_by} paid {value}{currency} for {paid_for}"
 msgstr "{paid_by} hat {value}{currency} für {paid_for} bezahlt"
 
-#: apps/transaction/templates/transaction/category_breakdown.html:30
 msgid "Back to transactions"
 msgstr "Zurück zu den Transaktionen"
 
-#: apps/transaction/templates/transaction/category_breakdown.html:33
 msgid "Category breakdown"
 msgstr "Kategorienübersicht"
 
-#: apps/transaction/templates/transaction/category_breakdown.html:34
 msgid "All recorded spend"
 msgstr "Alle erfassten Ausgaben"
 
-#: apps/transaction/templates/transaction/category_breakdown.html:36
 #, python-format
 msgid "Showing %(period)s."
 msgstr "Zeigt %(period)s."
 
-#: apps/transaction/templates/transaction/category_breakdown.html:48
 msgid "Currency breakdown"
 msgstr "Währungsaufteilung"
 
-#: apps/transaction/templates/transaction/category_breakdown.html:56
-#: apps/transaction/templates/transaction/category_breakdown.html:75
 #, python-format
 msgid ""
 "\n"
@@ -1675,50 +1127,34 @@ msgstr[1] ""
 "                                            %(category_count)s Kategorien\n"
 "                                        "
 
-#: apps/transaction/templates/transaction/category_breakdown.html:73
 msgid "Legend"
 msgstr "Legende"
 
-#: apps/transaction/templates/transaction/category_breakdown.html:103
 msgid "No tracked expenses yet. Add a transaction to populate the breakdown."
-msgstr ""
-"Noch keine erfassten Ausgaben. Füge eine Transaktion hinzu, um die "
-"Aufschlüsselung zu füllen."
+msgstr "Noch keine erfassten Ausgaben. Füge eine Transaktion hinzu, um die Aufschlüsselung zu füllen."
 
-#: apps/transaction/templates/transaction/category_breakdown.html:118
 msgid "Add expenses to unlock the breakdown."
 msgstr "Füge Ausgaben hinzu, um die Aufschlüsselung freizuschalten."
 
-#: apps/transaction/templates/transaction/category_manager.html:9
 #, python-format
 msgid "Manage categories for \"%(room_name)s\""
 msgstr "Kategorien für „%(room_name)s“ verwalten"
 
-#: apps/transaction/templates/transaction/category_manager.html:14
 msgid "Add or reorder categories that match how your group tracks spending."
-msgstr ""
-"Füge Kategorien hinzu oder ordne sie neu, die der Art und Weise entsprechen, "
-"wie deine Gruppe Ausgaben erfasst."
+msgstr "Füge Kategorien hinzu oder ordne sie neu, die der Art und Weise entsprechen, wie deine Gruppe Ausgaben erfasst."
 
-#: apps/transaction/templates/transaction/child_transaction_create.html:20
-#: apps/transaction/templates/transaction/edit.html:246
 msgid "For"
 msgstr "Für"
 
-#: apps/transaction/templates/transaction/child_transaction_create.html:29
 msgid "Remove this participant?"
 msgstr "Diese:n Teilnehmer:in entfernen?"
 
-#: apps/transaction/templates/transaction/child_transaction_create.html:37
-#: apps/transaction/templates/transaction/edit.html:276
 msgid "Child Transaction ID"
 msgstr "ID der Untertransaktion"
 
-#: apps/transaction/templates/transaction/create.html:8
 msgid "New transaction"
 msgstr "Neue Transaktion"
 
-#: apps/transaction/templates/transaction/create.html:10
 #, python-format
 msgid ""
 "\n"
@@ -1729,7 +1165,6 @@ msgstr ""
 "                        Eine Transaktion für \"%(room_name)s\" hinzufügen\n"
 "                    "
 
-#: apps/transaction/templates/transaction/create.html:18
 #, python-format
 msgid ""
 "\n"
@@ -1748,7 +1183,6 @@ msgstr[1] ""
 "                        %(member_count)s Mitglieder\n"
 "                    "
 
-#: apps/transaction/templates/transaction/create.html:26
 #, python-format
 msgid ""
 "\n"
@@ -1759,206 +1193,139 @@ msgstr ""
 "                        %(currency_sign)s bevorzugt\n"
 "                    "
 
-#: apps/transaction/templates/transaction/create.html:44
 msgid "Unable to add transaction"
 msgstr "Transaktion konnte nicht hinzugefügt werden"
 
-#: apps/transaction/templates/transaction/create.html:53
 msgid "Required details"
 msgstr "Erforderliche Angaben"
 
-#: apps/transaction/templates/transaction/create.html:56
 msgid "What was this?"
 msgstr "Was war das?"
 
-#: apps/transaction/templates/transaction/create.html:65
 msgid "e.g., Grocery run"
 msgstr "e.g., Einkaufen"
 
-#: apps/transaction/templates/transaction/create.html:72
-#: apps/transaction/templates/transaction/edit.html:155
 msgid "Maximum 50 characters."
 msgstr "Maximal 50 Zeichen."
 
-#: apps/transaction/templates/transaction/create.html:75
 msgid "Amount paid"
 msgstr "Bezahlter Betrag"
 
-#: apps/transaction/templates/transaction/create.html:92
 msgid "Total paid in the selected currency."
 msgstr "In der gewählten Währung insgesamt bezahlt."
 
-#: apps/transaction/templates/transaction/create.html:97
 msgid "Who paid?"
 msgstr "Wer hat bezahlt?"
 
-#: apps/transaction/templates/transaction/create.html:118
 msgid "Person covering this expense."
 msgstr "Die Person, die diese Ausgabe getragen hat."
 
-#: apps/transaction/templates/transaction/create.html:121
-#: apps/transaction/templates/transaction/detail.html:85
-#: apps/transaction/templates/transaction/edit.html:205
 msgid "Split between"
 msgstr "Aufgeteilt auf"
 
-#: apps/transaction/templates/transaction/create.html:137
 msgid "Hold Cmd/Ctrl to adjust beneficiaries."
 msgstr "Halte Cmd/Ctrl gedrückt, um die Begünstigten anzupassen."
 
-#: apps/transaction/templates/transaction/create.html:144
 msgid "Optional"
 msgstr "Optional"
 
-#: apps/transaction/templates/transaction/create.html:145
 msgid "More details"
 msgstr "Weitere Details"
 
-#: apps/transaction/templates/transaction/create.html:153
 msgid "Show fields"
 msgstr "Felder anzeigen"
 
-#: apps/transaction/templates/transaction/create.html:160
-#: apps/transaction/templates/transaction/edit.html:137
-#: apps/transaction/views/transaction_export_view.py:17
 msgid "Paid at"
 msgstr "Bezahlt am"
 
-#: apps/transaction/templates/transaction/create.html:173
 msgid "Use if the expense occurred earlier."
 msgstr "Verwenden, wenn die Ausgabe früher stattfand."
 
-#: apps/transaction/templates/transaction/create.html:197
 msgid "Defaults to the room preference."
 msgstr "Standardmäßig wird die Raumpräferenz verwendet."
 
-#: apps/transaction/templates/transaction/create.html:200
-#: apps/transaction/templates/transaction/edit.html:160
-#: apps/transaction/views/transaction_export_view.py:17
 msgid "Category"
 msgstr "Kategorie"
 
-#: apps/transaction/templates/transaction/create.html:215
 msgid "Tag this expense for dashboards and charts."
 msgstr "Markiere diese Ausgabe für Dashboards und Diagramme."
 
-#: apps/transaction/templates/transaction/create.html:219
-#: apps/transaction/templates/transaction/detail.html:76
-#: apps/transaction/templates/transaction/edit.html:309
-#: apps/transaction/templates/transaction/edit.html:311
 msgid "Notes"
 msgstr "Notizen"
 
-#: apps/transaction/templates/transaction/create.html:227
 msgid "Add split details, receipts, or reminders"
 msgstr "Füge Aufteilungsdetails, Belege oder Erinnerungen hinzu"
 
-#: apps/transaction/templates/transaction/create.html:230
 msgid "Up to 5000 characters."
 msgstr "Bis zu 5000 Zeichen."
 
-#: apps/transaction/templates/transaction/create.html:233
-#: apps/transaction/templates/transaction/edit.html:178
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:6
 msgid "Receipts"
 msgstr "Belege"
 
-#: apps/transaction/templates/transaction/create.html:245
 msgid "Upload receipts as PDF or image (max 5 MB each)."
 msgstr "Lade Belege als PDF oder Bild hoch (maximal 5 MB pro Datei)."
 
-#: apps/transaction/templates/transaction/create.html:253
-#: apps/transaction/templates/transaction/list.html:179
-#: apps/transaction/templates/transaction/list.html:180
 msgid "Add transaction"
 msgstr "Transaktion hinzufügen"
 
-#: apps/transaction/templates/transaction/create.html:263
 msgid "Room Slug"
 msgstr "Raum-Slug"
 
-#: apps/transaction/templates/transaction/create.html:281
 msgid "Groceries"
 msgstr "Lebensmittel"
 
-#: apps/transaction/templates/transaction/create.html:282
 msgid "Utilities"
 msgstr "Nebenkosten"
 
-#: apps/transaction/templates/transaction/create.html:283
 msgid "Dinner"
 msgstr "Abendessen"
 
-#: apps/transaction/templates/transaction/create.html:284
 msgid "Ride share"
 msgstr "Fahrgemeinschaft"
 
-#: apps/transaction/templates/transaction/create.html:285
 msgid "House supplies"
 msgstr "Haushaltsbedarf"
 
-#: apps/transaction/templates/transaction/detail.html:17
-#: apps/transaction/templates/transaction/edit.html:59
 msgid "Back to list"
 msgstr "Zurück zur Liste"
 
-#: apps/transaction/templates/transaction/detail.html:20
 msgid "Expense"
 msgstr "Ausgabe"
 
-#: apps/transaction/templates/transaction/detail.html:25
 msgid "paid"
 msgstr "bezahlt"
 
-#: apps/transaction/templates/transaction/detail.html:31
 msgid "Edit transaction"
 msgstr "Transaktion bearbeiten"
 
-#: apps/transaction/templates/transaction/detail.html:35
 msgid "Edit expense"
 msgstr "Ausgabe bearbeiten"
 
-#: apps/transaction/templates/transaction/detail.html:40
 msgid "This room is closed, so the breakdown is read-only."
 msgstr "Dieser Raum ist geschlossen, daher ist die Aufschlüsselung read-only."
 
-#: apps/transaction/templates/transaction/detail.html:47
 msgid "Total amount"
 msgstr "Gesamtbetrag"
 
-#: apps/transaction/templates/transaction/detail.html:54
-#: apps/transaction/templates/transaction/edit.html:91
-#: apps/transaction/views/transaction_export_view.py:17
 msgid "Paid by"
 msgstr "Bezahlt von"
 
-#: apps/transaction/templates/transaction/detail.html:58
 msgid "on"
 msgstr "am"
 
-#: apps/transaction/templates/transaction/detail.html:61
 #, python-format
 msgid "Recorded at %(recorded_time)s"
 msgstr "Erfasst um %(recorded_time)s"
 
-#: apps/transaction/templates/transaction/detail.html:66
-#: apps/transaction/templates/transaction/edit.html:147
-#: apps/transaction/templates/transaction/edit.html:149
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:23
-#: apps/transaction/views/transaction_export_view.py:17
 msgid "Description"
 msgstr "Beschreibung"
 
-#: apps/transaction/templates/transaction/detail.html:69
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:24
 msgid "No description"
 msgstr "Keine Beschreibung"
 
-#: apps/transaction/templates/transaction/detail.html:86
 msgid "Tap a row to edit the breakdown."
 msgstr "Tippe auf eine Zeile, um die Aufschlüsselung zu bearbeiten."
 
-#: apps/transaction/templates/transaction/detail.html:89
 #, python-format
 msgid ""
 "\n"
@@ -1977,7 +1344,6 @@ msgstr[1] ""
 "                        %(member_count)s Personen\n"
 "                    "
 
-#: apps/transaction/templates/transaction/detail.html:107
 #, python-format
 msgid ""
 "\n"
@@ -1985,73 +1351,52 @@ msgid ""
 "                                "
 msgstr ""
 "\n"
-"                                    Schuldet "
-"%(owed_value)s%(owed_currency)s\n"
+"                                    Schuldet %(owed_value)s%(owed_currency)s\n"
 "                                "
 
-#: apps/transaction/templates/transaction/detail.html:119
 msgid "No split data available for this transaction yet."
 msgstr "Für diese Transaktion liegen noch keine Splits-Daten vor."
 
-#: apps/transaction/templates/transaction/edit.html:62
 msgid "Editing expense"
 msgstr "Ausgabe bearbeiten"
 
-#: apps/transaction/templates/transaction/edit.html:63
 msgid "Adjust who paid and how it is split."
 msgstr "Leg fest, wer bezahlt hat und wie geteilt wird."
 
-#: apps/transaction/templates/transaction/edit.html:70
-#: apps/transaction/templates/transaction/edit.html:263
 msgid "Are you sure you wish to delete this transaction?"
 msgstr "Bist du sicher, dass du diese Transaktion löschen möchtest?"
 
-#: apps/transaction/templates/transaction/edit.html:77
 msgid "Delete"
 msgstr "Löschen"
 
-#: apps/transaction/templates/transaction/edit.html:100
 msgid "Total"
 msgstr "Gesamt"
 
-#: apps/transaction/templates/transaction/edit.html:122
 #, python-format
 msgid ""
 "\n"
-"                                    Current split: "
-"%(split_total)s%(split_currency)s\n"
+"                                    Current split: %(split_total)s%(split_currency)s\n"
 "                                "
 msgstr ""
 "\n"
-"                                    Aktuelle Aufteilung: "
-"%(split_total)s%(split_currency)s\n"
+"                                    Aktuelle Aufteilung: %(split_total)s%(split_currency)s\n"
 "                                "
 
-#: apps/transaction/templates/transaction/edit.html:169
 msgid "Use categories to group similar spend."
 msgstr "Nutze Kategorien, um ähnliche Ausgaben zu bündeln."
 
-#: apps/transaction/templates/transaction/edit.html:180
 msgid "Receipts stay on the detail page, so upload PDFs there instead of here."
 msgstr "Belege bleiben auf der Detailseite, lade PDFs dort statt hier hoch."
 
-#: apps/transaction/templates/transaction/edit.html:185
-msgid ""
-"You can continue editing this transaction; switch to the detail view if you "
-"need to manage uploads."
-msgstr ""
-"Du kannst diese Transaktion weiter bearbeiten; wechsle zur Detailansicht, "
-"wenn du Uploads verwalten möchtest."
+msgid "You can continue editing this transaction; switch to the detail view if you need to manage uploads."
+msgstr "Du kannst diese Transaktion weiter bearbeiten; wechsle zur Detailansicht, wenn du Uploads verwalten möchtest."
 
-#: apps/transaction/templates/transaction/edit.html:196
 msgid "Open detail view"
 msgstr "Detailansicht öffnen"
 
-#: apps/transaction/templates/transaction/edit.html:206
 msgid "Update each share or remove it entirely."
 msgstr "Aktualisiere jeden Anteil oder entferne ihn vollständig."
 
-#: apps/transaction/templates/transaction/edit.html:210
 #, python-format
 msgid ""
 "\n"
@@ -2070,113 +1415,81 @@ msgstr[1] ""
 "                                    %(participant_count)s Personen\n"
 "                                "
 
-#: apps/transaction/templates/transaction/edit.html:219
-msgid ""
-"⚠️ Total edits lock individual share inputs; the backend will rebalance "
-"splits automatically."
-msgstr ""
-"⚠️ Gesamte Änderungen sperren einzelne Anteile; das Backend gleicht die "
-"Splits automatisch aus."
+msgid "⚠️ Total edits lock individual share inputs; the backend will rebalance splits automatically."
+msgstr "⚠️ Gesamte Änderungen sperren einzelne Anteile; das Backend gleicht die Splits automatisch aus."
 
-#: apps/transaction/templates/transaction/edit.html:290
 msgid "No split entries yet."
 msgstr "Noch keine Splits erfasst."
 
-#: apps/transaction/templates/transaction/edit.html:302
 msgid "Add participant"
 msgstr "Teilnehmer hinzufügen"
 
-#: apps/transaction/templates/transaction/edit.html:317
 msgid "Add extra notes here"
 msgstr "Hier zusätzliche Notizen hinzufügen"
 
-#: apps/transaction/templates/transaction/list.html:169
 msgid "Room transactions"
 msgstr "Raumtransaktionen"
 
-#: apps/transaction/templates/transaction/list.html:171
 msgid "Click a row to explore the full breakdown."
 msgstr "Klicke eine Zeile, um die vollständige Aufschlüsselung zu sehen."
 
-#: apps/transaction/templates/transaction/list.html:173
 msgid "Record your first expense to see the running history here."
 msgstr "Erfasse deine erste Ausgabe, um den Verlauf hier anzuzeigen."
 
-#: apps/transaction/templates/transaction/list.html:192
 msgid "This room is closed, so transactions are read-only."
 msgstr "Dieser Raum ist geschlossen, daher sind Transaktionen nur lesbar."
 
-#: apps/transaction/templates/transaction/list.html:197
 msgid "Search"
 msgstr "Suche"
 
-#: apps/transaction/templates/transaction/list.html:203
 msgid "Filter by payer or description"
 msgstr "Nach Zahler:in oder Beschreibung filtern"
 
-#: apps/transaction/templates/transaction/list.html:217
 msgid "Details"
 msgstr "Details"
 
-#: apps/transaction/templates/transaction/list.html:218
 msgid "Actions"
 msgstr "Aktionen"
 
-#: apps/transaction/templates/transaction/list.html:245
 msgid "Nothing to show yet"
 msgstr "Noch nichts zu zeigen"
 
-#: apps/transaction/templates/transaction/list.html:246
 msgid "Start by logging an expense to build your history."
 msgstr "Erfasse zuerst eine Ausgabe, um deinen Verlauf aufzubauen."
 
-#: apps/transaction/templates/transaction/list.html:254
 msgid "Room snapshot"
 msgstr "Raumzusammenfassung"
 
-#: apps/transaction/templates/transaction/list.html:266
 msgid "Transactions logged"
 msgstr "Erfasste Transaktionen"
 
-#: apps/transaction/templates/transaction/list.html:272
 msgid "Last transaction"
 msgstr "Letzte Transaktion"
 
-#: apps/transaction/templates/transaction/list.html:277
 msgid "Invite your roommates to start sharing expenses."
 msgstr "Lade deine Mitbewohner ein, Ausgaben gemeinsam zu teilen."
 
-#: apps/transaction/templates/transaction/list.html:283
 msgid "Tips"
 msgstr "Tipps"
 
-#: apps/transaction/templates/transaction/list.html:285
 msgid "Use the search field to filter by payer or description."
 msgstr "Nutze das Suchfeld, um nach Zahler:in oder Beschreibung zu filtern."
 
-#: apps/transaction/templates/transaction/list.html:286
 msgid "Tap a row or the eye icon to review the split details."
-msgstr ""
-"Tippe eine Zeile oder das Augensymbol an, um die Split-Details anzusehen."
+msgstr "Tippe eine Zeile oder das Augensymbol an, um die Split-Details anzusehen."
 
-#: apps/transaction/templates/transaction/list.html:287
 msgid "The floating '+' button lets you capture a new transaction."
-msgstr ""
-"Der schwebende '+'-Button ermöglicht dir, eine neue Transaktion zu erfassen."
+msgstr "Der schwebende '+'-Button ermöglicht dir, eine neue Transaktion zu erfassen."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:79
 msgid "Back to debts"
 msgstr "Zurück zu Schulden"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:82
 msgid "Room spending overview"
 msgstr "Übersicht der Raumausgaben"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:83
 msgid "Who paid what"
 msgstr "Wer hat was bezahlt"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:92
 #, python-format
 msgid ""
 "\n"
@@ -2184,79 +1497,60 @@ msgid ""
 "                                "
 msgstr ""
 "\n"
-"                                    Insgesamt ausgegeben "
-"(%(currency_sign)s)\n"
+"                                    Insgesamt ausgegeben (%(currency_sign)s)\n"
 "                                "
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:103
 msgid "No spending yet"
 msgstr "Noch keine Ausgaben"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:104
 msgid "Add expenses to populate this dashboard."
 msgstr "Füge Ausgaben hinzu, um dieses Dashboard zu füllen."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:115
 msgid "Money spent by members"
 msgstr "Von Mitgliedern ausgegebenes Geld"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:116
 msgid "Who covered the bills"
 msgstr "Wer hat die Rechnungen bezahlt"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:149
 msgid "No payments recorded yet"
 msgstr "Noch keine Zahlungen erfasst"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:150
 msgid "As soon as someone logs an expense, their share appears here."
 msgstr "Sobald jemand eine Ausgabe erfasst, erscheint sein Anteil hier."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:161
 msgid "Money still owed"
 msgstr "Noch geschuldetes Geld"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:162
 msgid "Who needs to settle up"
 msgstr "Wer muss noch ausgleichen"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:166
 msgid "Pending balances"
 msgstr "Ausstehende Salden"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:171
 msgid "Open debt (after optimisation)"
 msgstr "Offene Schulden (nach Optimierung)"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:195
 msgid "Nothing owed right now"
 msgstr "Aktuell keine Schulden"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:196
 msgid "All participants are even for the tracked expenses."
 msgstr "Alle Teilnehmer sind für die erfassten Ausgaben ausgeglichen."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:202
 msgid "Covered by others (gross)"
 msgstr "Von anderen übernommen (brutto)"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:237
 msgid "Loading spending timeline…"
 msgstr "Verlauf wird geladen…"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:254
 msgid "Not enough data to render the chart yet."
 msgstr "Noch nicht genug Daten, um das Diagramm darzustellen."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:8
 msgid "Spending over time"
 msgstr "Ausgaben über die Zeit"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:9
 msgid "Expense build-up"
 msgstr "Ausgabenaufbau"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:11
 #, python-format
 msgid ""
 "\n"
@@ -2267,40 +1561,30 @@ msgstr ""
 "                                Zeigt %(period)s (%(start)s – %(end)s).\n"
 "                            "
 
-#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:19
 msgid "Spending trend ranges"
 msgstr "Ausgabentrend-Intervalle"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:33
 msgid "Updating..."
 msgstr "Wird aktualisiert..."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:46
 msgid "No data available"
 msgstr "Keine Daten verfügbar"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_trend.html:47
 msgid "Add a few expenses to unlock the timeline."
 msgstr "Füge ein paar Ausgaben hinzu, um die Timeline freizuschalten."
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:7
 msgid "Stored documents are linked to this transaction."
 msgstr "Gespeicherte Dokumente sind mit dieser Transaktion verknüpft."
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:21
 msgid "Permanently delete this receipt?"
 msgstr "Beleg dauerhaft löschen?"
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:26
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:27
 msgid "Delete receipt"
 msgstr "Beleg löschen"
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:50
 msgid "PDF receipt preview"
 msgstr "PDF-Beleg-Vorschau"
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:60
 #, python-format
 msgid ""
 "\n"
@@ -2311,99 +1595,72 @@ msgstr ""
 "                                            Hochgeladen von %(uploader)s\n"
 "                                        "
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:71
 msgid "No receipts have been attached to this transaction yet."
 msgstr "Dieser Transaktion wurden noch keine Belege beigefügt."
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:77
 msgid "Receipts cannot be uploaded after the room has been closed."
 msgstr "Belege können nach Schließen des Raums nicht mehr hochgeladen werden."
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:94
 msgid "Upload receipt"
 msgstr "Beleg hochladen"
 
-#: apps/transaction/templates/transaction/partials/_receipts_section.html:100
 msgid "PDF or PNG/JPEG/WebP/GIF (max 5 MB)."
 msgstr "PDF oder PNG/JPEG/WebP/GIF (max. 5 MB)."
 
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:7
 msgid "Create new category"
 msgstr "Neue Kategorie erstellen"
 
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:8
 msgid "Room-only categories"
 msgstr "Raumspezifische Kategorien"
 
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:34
 msgid "Emoji"
 msgstr "Emoji"
 
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:47
 msgid "Color"
 msgstr "Farbe"
 
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:62
 msgid "Order index"
 msgstr "Sortierungsindex"
 
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:81
 msgid "Set as default"
 msgstr "Als Standard festlegen"
 
-#: apps/transaction/templates/transaction/partials/_room_category_creation_form.html:87
 msgid "Add category"
 msgstr "Kategorie hinzufügen"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:7
 msgid "Available categories"
 msgstr "Verfügbare Kategorien"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:8
 msgid "Room catalog"
 msgstr "Raum Katalog"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:11
 msgid "Global defaults"
 msgstr "Globale Standards"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:13
 msgid "Customized"
 msgstr "Angepasst"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:32
 msgid "Remove"
 msgstr "Entfernen"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:40
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:98
 msgid "Default"
 msgstr "Standard"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:43
 msgid "Auto assigned"
 msgstr "Automatisch zugewiesen"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:56
 msgid "Order"
 msgstr "Sortierung"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:81
 msgid "Save order for this category"
 msgstr "Reihenfolge für diese Kategorie speichern"
 
-#: apps/transaction/templates/transaction/partials/_room_category_list.html:110
-msgid ""
-"No room-specific categories yet. Create one to override the shared baseline."
-msgstr ""
-"Noch keine raumspezifischen Kategorien vorhanden. Erstelle eine, um die "
-"gemeinsame Basislinie zu überschreiben."
+msgid "No room-specific categories yet. Create one to override the shared baseline."
+msgstr "Noch keine raumspezifischen Kategorien vorhanden. Erstelle eine, um die gemeinsame Basislinie zu überschreiben."
 
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:31
 msgid "Paid on"
 msgstr "Bezahlt am"
 
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:34
 #, python-format
 msgid ""
 "\n"
@@ -2414,52 +1671,38 @@ msgstr ""
 "                                Vor %(delta)s\n"
 "                            "
 
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:40
 msgid "Payer"
 msgstr "Zahler:in"
 
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:54
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:55
 msgid "View split details"
 msgstr "Split-Details ansehen"
 
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:68
 #, python-format
 msgid "No transactions match \"%(query)s\"."
 msgstr "Keine Transaktionen entsprechen \"%(query)s\"."
 
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:70
 msgid "No transactions to show yet."
 msgstr "Noch keine Transaktionen anzuzeigen."
 
-#: apps/transaction/templates/transaction/partials/_transaction_batch.html:104
 msgid "You're all caught up."
 msgstr "Du bist auf dem Laufenden."
 
-#: apps/transaction/views/category_manager_view.py:65
 msgid "Unable to update that category. Please correct the highlighted fields."
-msgstr ""
-"Diese Kategorie kann nicht aktualisiert werden. Bitte korrigiere die "
-"markierten Felder."
+msgstr "Diese Kategorie kann nicht aktualisiert werden. Bitte korrigiere die markierten Felder."
 
-#: apps/transaction/views/category_manager_view.py:164
 msgid "Category added."
 msgstr "Kategorie hinzugefügt."
 
-#: apps/transaction/views/category_manager_view.py:167
 #, python-format
 msgid "Category \"%(category)s\" deleted."
 msgstr "Kategorie \"%(category)s\" gelöscht."
 
-#: apps/transaction/views/transaction_export_view.py:17
 msgid "Paid for"
 msgstr "Bezahlt für"
 
-#: apps/transaction/views/transaction_export_view.py:35
 msgid "transactions"
 msgstr "transaktionen"
 
-#: apps/webpush/models/web_push_information.py:24
 #, python-brace-format
 msgid "Webpush Information for {user}"
 msgstr "Webpush-Information für {user}"

--- a/apps/locale/de/LC_MESSAGES/django.po
+++ b/apps/locale/de/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yamsa\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 09:28+0200\n"
+"POT-Creation-Date: 2026-04-24 10:01+0200\n"
 "PO-Revision-Date: 2025-01-01 00:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2204,47 +2204,47 @@ msgstr "Von Mitgliedern ausgegebenes Geld"
 msgid "Who covered the bills"
 msgstr "Wer hat die Rechnungen bezahlt"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:148
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:149
 msgid "No payments recorded yet"
 msgstr "Noch keine Zahlungen erfasst"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:149
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:150
 msgid "As soon as someone logs an expense, their share appears here."
 msgstr "Sobald jemand eine Ausgabe erfasst, erscheint sein Anteil hier."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:160
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:161
 msgid "Money still owed"
 msgstr "Noch geschuldetes Geld"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:161
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:162
 msgid "Who needs to settle up"
 msgstr "Wer muss noch ausgleichen"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:165
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:166
 msgid "Pending balances"
 msgstr "Ausstehende Salden"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:170
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:171
 msgid "Open debt (after optimisation)"
 msgstr "Offene Schulden (nach Optimierung)"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:194
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:195
 msgid "Nothing owed right now"
 msgstr "Aktuell keine Schulden"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:195
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:196
 msgid "All participants are even for the tracked expenses."
 msgstr "Alle Teilnehmer sind für die erfassten Ausgaben ausgeglichen."
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:201
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:202
 msgid "Covered by others (gross)"
 msgstr "Von anderen übernommen (brutto)"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:236
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:237
 msgid "Loading spending timeline…"
 msgstr "Verlauf wird geladen…"
 
-#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:253
+#: apps/transaction/templates/transaction/partials/_money_spent_on_room.html:254
 msgid "Not enough data to render the chart yet."
 msgstr "Noch nicht genug Daten, um das Diagramm darzustellen."
 

--- a/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
+++ b/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
@@ -119,7 +119,8 @@
                                 <i class="bi bi-graph-up"></i>
                                 <span class="text-center">
                                     {% for total_entry in total_money_spent %}
-                                        {{ total_entry.total_spent }}&nbsp;{{ total_entry.currency_sign }}{% if not forloop.last %}&thinsp;/&thinsp;{% endif %}
+                                        {{ total_entry.total_spent }}&nbsp;{{ total_entry.currency_sign }}
+                                        {% if not forloop.last %}&thinsp;/&thinsp;{% endif %}
                                     {% empty %}
                                         0
                                     {% endfor %}
@@ -127,28 +128,28 @@
                             </span>
                         </div>
                         {% for money_spent in money_spent_per_person_qs %}
-                                <div class="graph-row">
-                                    <div class="d-flex justify-content-between align-items-center mb-1">
-                                        <p class="graph-label mb-0">
-                                            {% autoescape off %}
-                                                {% parse_user_text money_spent.paid_by_name True %}
-                                            {% endautoescape %}
-                                        </p>
-                                        <p class="graph-value mb-0">{{ money_spent.total_spent_per_person }} {{ money_spent.currency_sign }}</p>
-                                    </div>
-                                    {% for total_entry in total_money_spent %}
-                                        {% if total_entry.currency_sign == money_spent.currency_sign %}
-                                            {% widthratio money_spent.total_spent_per_person total_entry.total_spent 100 as spent_percent %}
-                                            <div class="graph-bar" data-graph-width="{{ spent_percent }}%"></div>
-                                        {% endif %}
-                                    {% endfor %}
+                            <div class="graph-row">
+                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                    <p class="graph-label mb-0">
+                                        {% autoescape off %}
+                                            {% parse_user_text money_spent.paid_by_name True %}
+                                        {% endautoescape %}
+                                    </p>
+                                    <p class="graph-value mb-0">{{ money_spent.total_spent_per_person }} {{ money_spent.currency_sign }}</p>
                                 </div>
-                            {% empty %}
-                                <div class="empty-state mt-3">
-                                    <p class="fw-semibold mb-1">{% trans "No payments recorded yet" %}</p>
-                                    <p class="text-muted small mb-0">{% trans "As soon as someone logs an expense, their share appears here." %}</p>
-                                </div>
-                            {% endfor %}
+                                {% for total_entry in total_money_spent %}
+                                    {% if total_entry.currency_sign == money_spent.currency_sign %}
+                                        {% widthratio money_spent.total_spent_per_person total_entry.total_spent 100 as spent_percent %}
+                                        <div class="graph-bar" data-graph-width="{{ spent_percent }}%"></div>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        {% empty %}
+                            <div class="empty-state mt-3">
+                                <p class="fw-semibold mb-1">{% trans "No payments recorded yet" %}</p>
+                                <p class="text-muted small mb-0">{% trans "As soon as someone logs an expense, their share appears here." %}</p>
+                            </div>
+                        {% endfor %}
                     </div>
                 </div>
             </div>
@@ -200,24 +201,24 @@
                             <hr class="my-3">
                             <p class="text-muted small mb-2">{% trans "Covered by others (gross)" %}</p>
                             {% for covered in money_covered_for_person_qs %}
-                                    <div class="graph-row">
-                                        <div class="d-flex justify-content-between align-items-center mb-1">
-                                            <p class="graph-label mb-0">
-                                                {% autoescape off %}
-                                                    {% parse_user_text covered.paid_for__name True %}
-                                                {% endautoescape %}
-                                            </p>
-                                            <p class="graph-value mb-0">{{ covered.total_covered_for_person }} {{ covered.currency_sign }}</p>
-                                        </div>
-                                        {# Scale covered bars relative to total spent for this currency #}
-                                        {% for total_entry in total_money_spent %}
-                                            {% if total_entry.currency_sign == covered.currency_sign %}
-                                                {% widthratio covered.total_covered_for_person total_entry.total_spent 100 as covered_percent %}
-                                                <div class="graph-bar graph-bar-tertiary"
-                                                     data-graph-width="{{ covered_percent }}%"></div>
-                                            {% endif %}
-                                        {% endfor %}
+                                <div class="graph-row">
+                                    <div class="d-flex justify-content-between align-items-center mb-1">
+                                        <p class="graph-label mb-0">
+                                            {% autoescape off %}
+                                                {% parse_user_text covered.paid_for__name True %}
+                                            {% endautoescape %}
+                                        </p>
+                                        <p class="graph-value mb-0">{{ covered.total_covered_for_person }} {{ covered.currency_sign }}</p>
                                     </div>
+                                    {# Scale covered bars relative to total spent for this currency #}
+                                    {% for total_entry in total_money_spent %}
+                                        {% if total_entry.currency_sign == covered.currency_sign %}
+                                            {% widthratio covered.total_covered_for_person total_entry.total_spent 100 as covered_percent %}
+                                            <div class="graph-bar graph-bar-tertiary"
+                                                 data-graph-width="{{ covered_percent }}%"></div>
+                                        {% endif %}
+                                    {% endfor %}
+                                </div>
                             {% endfor %}
                         {% endif %}
                     </div>

--- a/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
+++ b/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
@@ -1,5 +1,5 @@
 {% extends "room/dashboard.html" %}
-{% load static room_tags i18n %}
+{% load static room_tags i18n core_tags %}
 {% load render_bundle from webpack_loader %}
 {% block tab_content %}
     <style nonce="{{ csp_nonce }}">
@@ -52,6 +52,10 @@
 
         .graph-bar.graph-bar-secondary::after {
             background: linear-gradient(90deg, rgba(25, 135, 84, 0.9), rgba(32, 201, 151, 0.9));
+        }
+
+        .graph-bar.graph-bar-tertiary::after {
+            background: linear-gradient(90deg, rgba(255, 153, 0, 0.85), rgba(255, 205, 57, 0.85));
         }
 
         .empty-state {
@@ -114,18 +118,15 @@
                             <span class="overview-chip">
                                 <i class="bi bi-graph-up"></i>
                                 <span class="text-center">
-                                    {% with total_entry=total_money_spent|first %}
-                                        {% if total_entry %}
-                                            {{ total_entry.total_spent }} {{ total_entry.currency_sign }}
-                                        {% else %}
-                                            0
-                                        {% endif %}
-                                    {% endwith %}
+                                    {% for total_entry in total_money_spent %}
+                                        {{ total_entry.total_spent }}&nbsp;{{ total_entry.currency_sign }}{% if not forloop.last %}&thinsp;/&thinsp;{% endif %}
+                                    {% empty %}
+                                        0
+                                    {% endfor %}
                                 </span>
                             </span>
                         </div>
-                        {% with total_entry=total_money_spent|first %}
-                            {% for money_spent in money_spent_per_person_qs %}
+                        {% for money_spent in money_spent_per_person_qs %}
                                 <div class="graph-row">
                                     <div class="d-flex justify-content-between align-items-center mb-1">
                                         <p class="graph-label mb-0">
@@ -135,12 +136,12 @@
                                         </p>
                                         <p class="graph-value mb-0">{{ money_spent.total_spent_per_person }} {{ money_spent.currency_sign }}</p>
                                     </div>
-                                    {% if total_entry %}
-                                        {% widthratio money_spent.total_spent_per_person total_entry.total_spent 100 as spent_percent %}
-                                        <div class="graph-bar" data-graph-width="{{ spent_percent }}%"></div>
-                                    {% else %}
-                                        <div class="graph-bar" data-graph-width="0%"></div>
-                                    {% endif %}
+                                    {% for total_entry in total_money_spent %}
+                                        {% if total_entry.currency_sign == money_spent.currency_sign %}
+                                            {% widthratio money_spent.total_spent_per_person total_entry.total_spent 100 as spent_percent %}
+                                            <div class="graph-bar" data-graph-width="{{ spent_percent }}%"></div>
+                                        {% endif %}
+                                    {% endfor %}
                                 </div>
                             {% empty %}
                                 <div class="empty-state mt-3">
@@ -148,7 +149,6 @@
                                     <p class="text-muted small mb-0">{% trans "As soon as someone logs an expense, their share appears here." %}</p>
                                 </div>
                             {% endfor %}
-                        {% endwith %}
                     </div>
                 </div>
             </div>
@@ -165,34 +165,63 @@
                                 <span class="text-center">{% trans "Pending balances" %}</span>
                             </span>
                         </div>
-                        {% with total_entry=total_money_spent|first %}
-                            {% for money_owed in money_owed_per_person_qs %}
-                                {% if money_owed.total_owed_per_person > 0 %}
+                        {# ── Open debts (after optimisation) ── #}
+                        {% if open_debts_per_person_qs %}
+                            <p class="text-muted small mb-2 mt-1">{% trans "Open debt (after optimisation)" %}</p>
+                            {% for debt_row in open_debts_per_person_qs %}
+                                <div class="graph-row">
+                                    <div class="d-flex justify-content-between align-items-center mb-1">
+                                        <p class="graph-label mb-0">
+                                            {% autoescape off %}
+                                                {% parse_user_text debt_row.debitor_name True %}
+                                            {% endautoescape %}
+                                        </p>
+                                        <p class="graph-value mb-0">{{ debt_row.total_open_debt }} {{ debt_row.currency_sign }}</p>
+                                    </div>
+                                    {% with max_val=max_open_debt_per_currency|get_item:debt_row.currency_sign %}
+                                        {% if max_val %}
+                                            {% widthratio debt_row.total_open_debt max_val 100 as open_debt_percent %}
+                                            <div class="graph-bar graph-bar-secondary"
+                                                 data-graph-width="{{ open_debt_percent }}%"></div>
+                                        {% else %}
+                                            <div class="graph-bar graph-bar-secondary" data-graph-width="0%"></div>
+                                        {% endif %}
+                                    {% endwith %}
+                                </div>
+                            {% endfor %}
+                        {% else %}
+                            <div class="empty-state mt-3">
+                                <p class="fw-semibold mb-1">{% trans "Nothing owed right now" %}</p>
+                                <p class="text-muted small mb-0">{% trans "All participants are even for the tracked expenses." %}</p>
+                            </div>
+                        {% endif %}
+                        {# ── Gross amount covered by others per person ── #}
+                        {% if money_covered_for_person_qs %}
+                            <hr class="my-3">
+                            <p class="text-muted small mb-2">{% trans "Covered by others (gross)" %}</p>
+                            {% for covered in money_covered_for_person_qs %}
+                                {% if covered.total_covered_for_person > 0 %}
                                     <div class="graph-row">
                                         <div class="d-flex justify-content-between align-items-center mb-1">
                                             <p class="graph-label mb-0">
                                                 {% autoescape off %}
-                                                    {% parse_user_text money_owed.paid_for__name True %}
+                                                    {% parse_user_text covered.paid_for__name True %}
                                                 {% endautoescape %}
                                             </p>
-                                            <p class="graph-value mb-0">{{ money_owed.total_owed_per_person }} {{ money_owed.currency_sign }}</p>
+                                            <p class="graph-value mb-0">{{ covered.total_covered_for_person }} {{ covered.currency_sign }}</p>
                                         </div>
-                                        {% if total_entry %}
-                                            {% widthratio money_owed.total_owed_per_person total_entry.total_spent 100 as owed_percent %}
-                                            <div class="graph-bar graph-bar-secondary"
-                                                 data-graph-width="{{ owed_percent }}%"></div>
-                                        {% else %}
-                                            <div class="graph-bar graph-bar-secondary" data-graph-width="0%"></div>
-                                        {% endif %}
+                                        {# Scale covered bars relative to total spent for this currency #}
+                                        {% for total_entry in total_money_spent %}
+                                            {% if total_entry.currency_sign == covered.currency_sign %}
+                                                {% widthratio covered.total_covered_for_person total_entry.total_spent 100 as covered_percent %}
+                                                <div class="graph-bar graph-bar-tertiary"
+                                                     data-graph-width="{{ covered_percent }}%"></div>
+                                            {% endif %}
+                                        {% endfor %}
                                     </div>
                                 {% endif %}
-                            {% empty %}
-                                <div class="empty-state mt-3">
-                                    <p class="fw-semibold mb-1">{% trans "Nothing owed right now" %}</p>
-                                    <p class="text-muted small mb-0">{% trans "All participants are even for the tracked expenses." %}</p>
-                                </div>
                             {% endfor %}
-                        {% endwith %}
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
+++ b/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
@@ -200,7 +200,6 @@
                             <hr class="my-3">
                             <p class="text-muted small mb-2">{% trans "Covered by others (gross)" %}</p>
                             {% for covered in money_covered_for_person_qs %}
-                                {% if covered.total_covered_for_person > 0 %}
                                     <div class="graph-row">
                                         <div class="d-flex justify-content-between align-items-center mb-1">
                                             <p class="graph-label mb-0">
@@ -219,7 +218,6 @@
                                             {% endif %}
                                         {% endfor %}
                                     </div>
-                                {% endif %}
                             {% endfor %}
                         {% endif %}
                     </div>

--- a/apps/transaction/tests/test_views/test_money_spent_views.py
+++ b/apps/transaction/tests/test_views/test_money_spent_views.py
@@ -29,16 +29,16 @@ class TestMoneySpentViews:
         assert total_entry["currency_sign"] == room.preferred_currency.sign
 
         spent_per_person = list(context["money_spent_per_person_qs"])
-        owed_per_person = list(context["money_owed_per_person_qs"])
+        covered_per_person = list(context["money_covered_for_person_qs"])
 
         assert spent_per_person, "expected money_spent_per_person results"
-        assert owed_per_person, "expected money_owed_per_person results"
+        assert covered_per_person, "expected money_covered_for_person results"
 
         assert spent_per_person[0]["paid_by_name"] == user.name
         assert spent_per_person[0]["total_spent_per_person"] == expected_total
 
-        assert owed_per_person[0]["paid_for__name"] == guest_user.name
-        assert owed_per_person[0]["total_owed_per_person"] == expected_total
+        assert covered_per_person[0]["paid_for__name"] == guest_user.name
+        assert covered_per_person[0]["total_covered_for_person"] == expected_total
 
     def test_money_spent_trend_view_builds_chart_payload(self, client, room, user, guest_user):
         _, child_transactions = create_parent_transaction_with_optimisation(
@@ -77,12 +77,12 @@ class TestMoneySpentViews:
 
         response = client.get(reverse("debt:money-spent-on-room", kwargs={"room_slug": room.slug}))
         assert response.status_code == http.HTTPStatus.OK
-        owed_per_person = list(response.context_data["money_owed_per_person_qs"])
+        covered_per_person = list(response.context_data["money_covered_for_person_qs"])
 
-        assert owed_per_person, "expected money_owed_per_person results"
-        assert len(owed_per_person) == 1
-        assert owed_per_person[0]["paid_for__name"] == guest_user.name
-        assert owed_per_person[0]["total_owed_per_person"] == sum(
+        assert covered_per_person, "expected money_covered_for_person results"
+        assert len(covered_per_person) == 1
+        assert covered_per_person[0]["paid_for__name"] == guest_user.name
+        assert covered_per_person[0]["total_covered_for_person"] == sum(
             transaction.value for transaction in child_transactions if transaction.paid_for == guest_user
         )
 


### PR DESCRIPTION
## Problem

The "Who needs to settle up" section on the Money Overview page was semantically wrong in three ways:

1. **Wrong data source**: It showed gross amounts paid by others for each person (raw `ChildTransaction` sums), not actual outstanding debts. This ignored the debt optimisation step entirely and showed numbers that did not match what people actually owe.
2. **Multi-currency bar scaling bug**: Both bar sections used `total_money_spent|first` to determine bar width, meaning all bars were scaled relative to the first currency only — wrong for rooms with mixed currencies.
3. **Settled debts not excluded**: The old query had no filter on `settled=False`, so paid-off debts still influenced the display.

## Changes

### `money_spent_on_room_view.py`
- Renamed `money_owed_per_person_qs` → `money_covered_for_person_qs` (honest naming: gross consumption)
- Added `open_debts_per_person_qs`: queries the `Debt` model directly, filtered to `settled=False`, reflecting the actual optimised outstanding amounts
- Added `max_open_debt_per_currency`: dict used for correct per-currency bar scaling in the template

### `_money_spent_on_room.html`
- **"Who needs to settle up"** now shows two distinct sections:
  - **Open debt (after optimisation)** — green bars, scaled relative to max debt per currency
  - **Covered by others (gross)** — orange bars, scaled relative to total spent per currency
- **"Who covered the bills"**: bar scaling now matches per currency instead of using `|first`
- Chip in "Who covered the bills" now shows all currencies instead of just the first
- New CSS class `.graph-bar-tertiary` (orange gradient)
- Added `{% load core_tags %}`

### `core_tags.py`
- Added `get_item` template filter for dict key lookups in templates

### Tests
- Updated existing test to use renamed `money_covered_for_person_qs`
- Added `test_open_debts_per_person_qs_only_returns_unsettled`
- Added `test_max_open_debt_per_currency_reflects_max_unsettled`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Business Impact

The Money Overview page now displays accurate financial information:
- **"Who needs to settle up" section** shows actual outstanding debts after debt optimization (rather than gross consumption amounts), giving users the true settlement requirements
- **Multi-currency support** fixed—bars and summaries now correctly scale per currency instead of only using the first currency, preventing misleading comparisons in diverse expense groups
- **Settled debts excluded** from open debt calculations, eliminating confusion about which debts actually require settlement

## Technical Changes

**View Layer (`money_spent_on_room_view.py`)**
- Renamed `money_owed_per_person_qs` → `money_covered_for_person_qs` to clarify that this represents gross consumption (not optimized debts)
- Added `open_debts_per_person_qs` context variable querying unsettled `Debt` objects, providing optimized outstanding amounts
- Added `max_open_debt_per_currency` dict to enable per-currency bar scaling

**Template Layer (`_money_spent_on_room.html`)**
- Restructured "Who needs to settle up" into two distinct sections:
  - "Open debt (after optimisation)" using green bars scaled per currency
  - "Covered by others (gross)" using orange bars for context
- Fixed "Who covered the bills" bar scaling to use per-currency maxima instead of single first-currency reference
- Updated all currency displays to show all applicable currencies instead of only the first

**Template Filter Support (`core_tags.py`)**
- Added `get_item` filter to enable template-level dictionary lookups, required for the per-currency scaling logic

## Testing

- Existing test updated to use the renamed `money_covered_for_person_qs`
- Added `test_open_debts_per_person_qs_only_returns_unsettled` to verify settled debts are properly filtered
- Added `test_max_open_debt_per_currency_reflects_max_unsettled` to validate per-currency scaling data

## Required Follow-up

- **Verification**: Test the Money Overview page in multi-currency scenarios to confirm bar scaling and chip displays are accurate
- **Edge cases**: Validate behavior when a user has no open debts (empty state should display cleanly)
- **Regression testing**: Confirm "Who covered the bills" section still functions correctly with the per-currency scaling changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->