### PR TITLE
fix: render graph bars via inline CSS var instead of JS-driven data attribute

### DIFF
--- a/apps/static/js/navigation.js
+++ b/apps/static/js/navigation.js
@@ -176,7 +176,6 @@ window.bootstrap = bootstrap;
   };
 
   const PROFILE_PICTURE_FALLBACK_SELECTOR = '[data-profile-picture-fallback-url]';
-  const GRAPH_WIDTH_SELECTOR = '[data-graph-width]';
   const CATEGORY_COLOR_SELECTOR = '[data-category-color]';
 
   const initProfilePictureFallbacks = () => {
@@ -207,13 +206,6 @@ window.bootstrap = bootstrap;
   };
 
   const applyDataStyleVars = () => {
-    document.querySelectorAll(GRAPH_WIDTH_SELECTOR).forEach((element) => {
-      const graphWidth = element.dataset.graphWidth;
-      if (graphWidth) {
-        element.style.setProperty('--graph-width', graphWidth);
-      }
-    });
-
     document.querySelectorAll(CATEGORY_COLOR_SELECTOR).forEach((element) => {
       const categoryColor = element.dataset.categoryColor;
       if (categoryColor) {

--- a/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
+++ b/apps/transaction/templates/transaction/partials/_money_spent_on_room.html
@@ -140,7 +140,7 @@
                                 {% for total_entry in total_money_spent %}
                                     {% if total_entry.currency_sign == money_spent.currency_sign %}
                                         {% widthratio money_spent.total_spent_per_person total_entry.total_spent 100 as spent_percent %}
-                                        <div class="graph-bar" data-graph-width="{{ spent_percent }}%"></div>
+                                        <div class="graph-bar" style="--graph-width: {{ spent_percent }}%"></div>
                                     {% endif %}
                                 {% endfor %}
                             </div>
@@ -183,9 +183,9 @@
                                         {% if max_val %}
                                             {% widthratio debt_row.total_open_debt max_val 100 as open_debt_percent %}
                                             <div class="graph-bar graph-bar-secondary"
-                                                 data-graph-width="{{ open_debt_percent }}%"></div>
+                                                 style="--graph-width: {{ open_debt_percent }}%"></div>
                                         {% else %}
-                                            <div class="graph-bar graph-bar-secondary" data-graph-width="0%"></div>
+                                            <div class="graph-bar graph-bar-secondary" style="--graph-width: 0%"></div>
                                         {% endif %}
                                     {% endwith %}
                                 </div>
@@ -215,7 +215,7 @@
                                         {% if total_entry.currency_sign == covered.currency_sign %}
                                             {% widthratio covered.total_covered_for_person total_entry.total_spent 100 as covered_percent %}
                                             <div class="graph-bar graph-bar-tertiary"
-                                                 data-graph-width="{{ covered_percent }}%"></div>
+                                                 style="--graph-width: {{ covered_percent }}%"></div>
                                         {% endif %}
                                     {% endfor %}
                                 </div>


### PR DESCRIPTION
## Problem

The graph bars on the Money Overview page were not rendering their colour fill. The bars use a `::after` pseudo-element whose `width` is driven by `--graph-width`. This CSS variable was previously set by `applyDataStyleVars()` in the navigation JS bundle, which reads `data-graph-width` attributes and calls `element.style.setProperty("--graph-width", value)`.

If the bundle loads slightly late, fails to load, or `htmx:afterSwap` fires before the bar elements are in the DOM, the variable is never set and the bars stay empty.

## Fix

Set `style="--graph-width: {{ percent }}%"` directly in the template instead of using `data-graph-width`. This removes the JS dependency entirely — the CSS variable is available on first paint with no timing or bundle dependency.

## Change

One-line change per bar element in `_money_spent_on_room.html`: replace `data-graph-width="..."` with `style="--graph-width: ..."`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix graph bar rendering with inline CSS variables

Replaces JavaScript-driven data attributes with inline CSS custom properties to ensure graph bars render on first paint, eliminating timing dependencies on JavaScript bundle loading.

### Business Impact

**Problem solved**: Graph bars on the Money Overview page previously failed to render their width due to a two-step process dependency:
1. The old `data-graph-width` attribute was read by JavaScript (`applyDataStyleVars()` in the navigation bundle)
2. JavaScript then set the CSS custom property `--graph-width` via `element.style.setProperty()`

If the JS bundle loaded late, failed to load, or HTMX partial swaps fired before elements were added to the DOM, the CSS variable was never set and bars remained empty.

**Solution**: Set `--graph-width` as an inline style directly in the template (`style="--graph-width: {{ percent }}%"`), eliminating the JavaScript dependency and ensuring bars render correctly on first paint.

### Changes Made

- Updated 4 graph bar elements in `apps/transaction/templates/transaction/partials/_money_spent_on_room.html`:
  - Primary graph: "Who covered the bills" spending bar
  - Secondary graph: "Who needs to settle up" unsettled debt bar (including zero-width fallback)
  - Tertiary graph: "Covered by others (gross)" bar
- Leverages existing CSS rule `.graph-bar::after { width: var(--graph-width, 0%); }` which already expected this variable

### Recommended Follow-Up

1. **Visual regression testing**: Verify that all three graph types render correctly with proper width on initial page load
2. **E2E testing**: Test rendering on slow network conditions and ensure bars display before JavaScript bundle loads
3. **HTMX partial update verification**: Confirm that graph bars update correctly when partial swaps occur (the `htmx:afterSwap` scenarios that were previously problematic)
4. **Browser compatibility**: Verify CSS custom property support across target browsers (supported in all modern browsers, IE not supported)

### Testing Status

Existing unit tests in `apps/debt/tests/test_views/test_money_spent_on_room_view.py` and `apps/transaction/tests/test_views/test_money_spent_views.py` cover context data aggregation and correctness. No visual rendering tests appear to exist for bar width display—these should be added to prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->