### PR TITLE
Bugfix: Fix passkey deployment

### DIFF
--- a/apps/config/settings.py
+++ b/apps/config/settings.py
@@ -229,7 +229,9 @@ STORAGES = {
     "staticfiles": {
         # Turn on WhiteNoise storage backend that takes care of compressing static files
         # and creating unique names for each version, so they can safely be cached forever.
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        # TODO CT: Workaround for missing bootstrap-toggle.min.js.map in django-passkeys — revert to
+        #       "whitenoise.storage.CompressedManifestStaticFilesStorage" once fixed upstream.
+        "BACKEND": "apps.config.storage.ManifestStaticFilesStorage",
     },
 }
 

--- a/apps/config/storage.py
+++ b/apps/config/storage.py
@@ -8,10 +8,10 @@ class ManifestStaticFilesStorage(CompressedManifestStaticFilesStorage):
     # TODO CT: Check if django-passkeys has fixed the missing bootstrap-toggle.min.js.map
     #       and remove this class + revert settings.py to CompressedManifestStaticFilesStorage.
     #       Tracking issue: https://github.com/mkalioby/django-passkeys/issues
-    def _stored_name(self, name, hashed_files):
+    def _stored_name(self, name, hashed_files) -> str:
         try:
             return super()._stored_name(name, hashed_files)
         except ValueError:
-            if name.endswith(".map"):
+            if name.endswith("bootstrap-toggle.min.js.map"):
                 return name
             raise

--- a/apps/config/storage.py
+++ b/apps/config/storage.py
@@ -1,0 +1,17 @@
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+
+class ManifestStaticFilesStorage(CompressedManifestStaticFilesStorage):
+    # manifest_strict only guards stored_name() (runtime), not _stored_name()
+    # (post-processing). Override _stored_name() so missing source-map references
+    # from third-party packages don't abort collectstatic.
+    # TODO CT: Check if django-passkeys has fixed the missing bootstrap-toggle.min.js.map
+    #       and remove this class + revert settings.py to CompressedManifestStaticFilesStorage.
+    #       Tracking issue: https://github.com/mkalioby/django-passkeys/issues
+    def _stored_name(self, name, hashed_files):
+        try:
+            return super()._stored_name(name, hashed_files)
+        except ValueError:
+            if name.endswith(".map"):
+                return name
+            raise

--- a/apps/config/tests/test_storage.py
+++ b/apps/config/tests/test_storage.py
@@ -1,0 +1,29 @@
+import pytest
+
+from apps.config.storage import ManifestStaticFilesStorage
+
+
+class TestManifestStaticFilesStoredName:
+    def _make_storage(self):
+        return ManifestStaticFilesStorage.__new__(ManifestStaticFilesStorage)
+
+    def test_missing_bootstrap_toggle_map_returns_name(self, monkeypatch):
+        storage = self._make_storage()
+        base = ManifestStaticFilesStorage.__bases__[0]
+        monkeypatch.setattr(
+            base, "_stored_name", lambda self, name, hashed_files: (_ for _ in ()).throw(ValueError("missing"))
+        )
+
+        result = storage._stored_name("passkeys/js/bootstrap-toggle.min.js.map", {})
+
+        assert result == "passkeys/js/bootstrap-toggle.min.js.map"
+
+    def test_missing_non_map_asset_raises(self, monkeypatch):
+        storage = self._make_storage()
+        base = ManifestStaticFilesStorage.__bases__[0]
+        monkeypatch.setattr(
+            base, "_stored_name", lambda self, name, hashed_files: (_ for _ in ()).throw(ValueError("missing"))
+        )
+
+        with pytest.raises(ValueError):
+            storage._stored_name("some/missing/asset.js", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "django-extensions==4.*",
     "django-htmx==1.*",
     "django-minify-html==1.*",
-    "django-passkeys>=2.0",
+    "django-passkeys==2.*",
     "django-pony-express==2.*",
     "django-webpack-loader==3.*",
     "django[argon2]==6.*",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Business Impact

This PR fixes a deployment blocker for the passkey authentication feature. The application was unable to deploy with `django-passkeys` due to a missing source map file (`bootstrap-toggle.min.js.map`) that the dependency references but doesn't provide. Without this fix, static file collection fails during deployment, preventing the application from starting.

## Technical Changes

- **New file**: `apps/config/storage.py` — Introduces a custom `ManifestStaticFilesStorage` class extending WhiteNoise's `CompressedManifestStaticFilesStorage`
- **Updated**: `apps/config/settings.py` — Switches the static files backend from WhiteNoise's standard storage to the custom workaround implementation
- The custom storage gracefully handles missing source map files by returning their unmodified names instead of raising `ValueError`, while still validating all other static assets

## Follow-up Actions Required

- **Monitor upstream**: Track https://github.com/mkalioby/django-passkeys/issues for a fix to the missing `bootstrap-toggle.min.js.map` file in django-passkeys
- **Revert pending**: Once the upstream issue is resolved, revert both files to use WhiteNoise's standard `CompressedManifestStaticFilesStorage` (as noted in TODO comments)
- **Testing**: Existing CI/CD workflow (`django-tests.yml`) will validate static file collection during test runs — no additional tests were added; rely on coverage monitoring to ensure the fix doesn't degrade static file handling for non-source-map assets

## Risk & Scope

- **Medium risk**: Changes core Django static file handling but isolates the workaround to source map files only
- **Minimal scope**: Two files changed (20 lines total), no migrations or configuration migrations required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->