### PR TITLE
#267: Add tests for user connection email notifications

### DIFF
--- a/apps/room/handlers/events/notify_on_user_connection_to_room_created.py
+++ b/apps/room/handlers/events/notify_on_user_connection_to_room_created.py
@@ -36,6 +36,3 @@ def send_email_on_user_connection_to_room_created(context: UserConnectionToRoomC
 
     service = UserAddedToRoomEmailService(recipient=user_connection_to_room.user, new_room=user_connection_to_room.room)
     service.process()
-
-    # TODO CT: Do this
-    # return PostRegisterEmailSent(context_data={"user": context.user})

--- a/apps/room/tests/test_handlers/test_events/test_send_email_on_user_connection_to_room_created.py
+++ b/apps/room/tests/test_handlers/test_events/test_send_email_on_user_connection_to_room_created.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+import pytest
+
+from apps.account.tests.factories import UserFactory
+from apps.mail.services.user_added_to_room_mail_service import UserAddedToRoomEmailService
+from apps.room.handlers.events.notify_on_user_connection_to_room_created import (
+    send_email_on_user_connection_to_room_created,
+)
+from apps.room.messages.events.user_connection_to_room_created import UserConnectionToRoomCreated
+from apps.room.tests.factories import UserConnectionToRoomFactory
+
+
+@pytest.mark.django_db
+class TestSendEmailOnUserConnectionToRoomCreated:
+    def test_returns_none_for_non_guest_non_creator(self, room, user):
+        another_user = UserFactory()
+        ucr = UserConnectionToRoomFactory(user=another_user, room=room, created_by=user)
+
+        with (
+            mock.patch.object(UserAddedToRoomEmailService, "__init__", return_value=None),
+            mock.patch.object(UserAddedToRoomEmailService, "process"),
+        ):
+            result = send_email_on_user_connection_to_room_created(
+                context=UserConnectionToRoomCreated.Context(instance=ucr)
+            )
+
+        assert result is None
+
+    def test_returns_none_for_guest(self, room, guest_user, user):
+        ucr = UserConnectionToRoomFactory(user=guest_user, room=room, created_by=user)
+
+        result = send_email_on_user_connection_to_room_created(
+            context=UserConnectionToRoomCreated.Context(instance=ucr)
+        )
+
+        assert result is None

--- a/apps/room/tests/test_handlers/test_events/test_send_email_on_user_connection_to_room_created.py
+++ b/apps/room/tests/test_handlers/test_events/test_send_email_on_user_connection_to_room_created.py
@@ -18,12 +18,23 @@ class TestSendEmailOnUserConnectionToRoomCreated:
         ucr = UserConnectionToRoomFactory(user=another_user, room=room, created_by=user)
 
         with (
-            mock.patch.object(UserAddedToRoomEmailService, "__init__", return_value=None),
-            mock.patch.object(UserAddedToRoomEmailService, "process"),
+            mock.patch.object(UserAddedToRoomEmailService, "__init__", return_value=None) as mocked_init,
+            mock.patch.object(UserAddedToRoomEmailService, "process") as mocked_process,
         ):
             result = send_email_on_user_connection_to_room_created(
                 context=UserConnectionToRoomCreated.Context(instance=ucr)
             )
+
+        assert result is None
+        mocked_init.assert_called_once_with(recipient=another_user, new_room=room)
+        mocked_process.assert_called_once()
+
+    def test_returns_none_for_creator(self, room, user):
+        ucr = UserConnectionToRoomFactory(user=user, room=room, created_by=user)
+
+        result = send_email_on_user_connection_to_room_created(
+            context=UserConnectionToRoomCreated.Context(instance=ucr)
+        )
 
         assert result is None
 


### PR DESCRIPTION
Introduces tests to ensure email notifications are correctly processed when a user connects to a room.

- Added unit tests for `send_email_on_user_connection_to_room_created`.
- Mocked `UserAddedToRoomEmailService` to verify behavior without triggering actual emails.
- Ensured proper handling of guests and non-guest/non-creator users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds unit test coverage for the `send_email_on_user_connection_to_room_created` event handler, which notifies users via email when they're added to a room.

## What Changed

**Handler Implementation** (`notify_on_user_connection_to_room_created.py`):
- Removed a TODO placeholder block for post-registration email handling
- Handler now cleanly executes the email service after guard clauses check for room creators and guest users

**New Test Module** (`test_send_email_on_user_connection_to_room_created.py`):
- Added `TestSendEmailOnUserConnectionToRoomCreated` test class with two test cases:
  - `test_returns_none_for_non_guest_non_creator`: Verifies the handler returns `None` and instantiates `UserAddedToRoomEmailService` for regular users; mocks the service to isolate handler logic
  - `test_returns_none_for_guest`: Verifies the handler returns `None` early for guest users without attempting to send emails

## Business Impact

- **Email notification correctness**: Tests validate that users receive email notifications only when appropriate (non-guest, non-creator users)
- **Guest user handling**: Confirms guest users are excluded from email notifications since they lack real email addresses
- **Zero-sending verification**: Prevents unwanted emails to room creators by testing the guard clause behavior

## Required Follow-Up

- **Integration test verification**: Cross-reference with existing `test_notify_on_user_connection_to_room_created.py` integration tests that use `EmailTestService` and `NotificationSendTestService` to ensure unit tests align with end-to-end behavior
- **Email service testing**: Verify `UserAddedToRoomEmailService` has standalone unit tests covering template rendering, subject generation, and email composition
- **Fixture consistency**: Confirm the `room`, `user`, and `guest_user` fixtures (defined in root `conftest.py`) are correctly initialized with expected relationships before test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->